### PR TITLE
Implementation of Adding Heart to Particular Store

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/Heart.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/Heart.java
@@ -1,0 +1,37 @@
+package com.ktc.matgpt.heart.storeHeart;
+
+import com.ktc.matgpt.store.Store;
+import com.ktc.matgpt.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+
+@Entity
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "heart_tb")
+public class Heart {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name="user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name="store_id")
+    private Store store;
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartJPARepository.java
@@ -1,0 +1,20 @@
+package com.ktc.matgpt.heart.storeHeart;
+
+import com.ktc.matgpt.store.Store;
+import com.ktc.matgpt.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface HeartJPARepository extends JpaRepository<Heart, Long> {
+
+    @Query("select h from Heart h where h.user.id = :userId")
+    Optional<Heart> findHeartByUserId(Long userId);
+
+    @Query( "select h.store from Heart h where h.user.id = :userId")
+    List<Store> findStoresByUserId(Long userId);
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartResponseDTO.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartResponseDTO.java
@@ -1,0 +1,46 @@
+package com.ktc.matgpt.heart.storeHeart;
+
+import com.ktc.matgpt.store.Store;
+import com.ktc.matgpt.store.entity.Category;
+import com.ktc.matgpt.user.entity.User;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class HeartResponseDTO {
+
+    @Getter
+    @Setter
+    public static class FindAllLikeStoresDTO{
+
+        private Long userId;
+        private List<StoreDTO> storeList;
+
+        public FindAllLikeStoresDTO(User user, List<Store> storeList){
+            this.userId = user.getId();
+            this.storeList = storeList.stream().map(StoreDTO::new).collect(Collectors.toList());
+
+
+        }
+
+        @Getter @Setter
+        public class StoreDTO{
+            private Long storeId;
+            private String storeName;
+            private Category category;
+            private double ratingAvg;
+            private int numsOfReview;
+
+            public StoreDTO(Store store){
+                this.storeId = store.getId();
+                this.storeName = store.getStoreName();
+                this.category = store.getCategory();
+                this.ratingAvg = store.getRatingAvg();
+                this.numsOfReview = store.getNumsOfReview();
+            }
+        }
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartRestController.java
@@ -1,0 +1,46 @@
+package com.ktc.matgpt.heart.storeHeart;
+
+
+import com.ktc.matgpt.security.UserPrincipal;
+import com.ktc.matgpt.user.entity.User;
+import com.ktc.matgpt.utils.ApiUtils;
+import jakarta.validation.Valid;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("")
+public class HeartRestController {
+
+    private final HeartService heartService;
+
+    //
+    @GetMapping("/stores/like")
+    public ResponseEntity<?> findAllStores(@AuthenticationPrincipal UserPrincipal userPrincipal){
+        HeartResponseDTO.FindAllLikeStoresDTO heartResponseDTO = heartService.findStoresByUser(userPrincipal.getEmail());
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(heartResponseDTO);
+        return ResponseEntity.ok(apiResult);
+
+    }
+
+    //특정 store에 좋아요 누르기
+    @PostMapping("/stores/{storeId}/like")
+    public ResponseEntity<?> addHeart(@PathVariable(value = "storeId", required = true) Long storeId , @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        heartService.addHeartToStore(storeId, userPrincipal.getEmail());
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success("success");
+        return ResponseEntity.ok(apiResult);
+    }
+
+
+    //특정 store에 좋아요 취소하기
+//    @DeleteMapping("/stores/{storeId}/like")
+//    public ResponseEntity<?> deleteHeart(@PathVariable(value = "storeId", required = true) Long storeId , @AuthenticationPrincipal UserPrincipal userPrincipal){
+//
+//    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/heart/storeHeart/HeartService.java
@@ -1,0 +1,58 @@
+package com.ktc.matgpt.heart.storeHeart;
+
+
+import com.ktc.matgpt.security.UserPrincipal;
+import com.ktc.matgpt.store.Store;
+import com.ktc.matgpt.store.StoreJPARepository;
+import com.ktc.matgpt.user.entity.User;
+import com.ktc.matgpt.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HeartService {
+
+    private final StoreJPARepository storeJPARepository;
+    private final UserRepository userRepository;
+    private final HeartJPARepository heartJPARepository;
+
+
+    @Transactional
+    public void addHeartToStore(Long storeId, String email){
+
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
+        Store store = storeJPARepository.findById(storeId).orElseThrow(() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다."));
+
+        //이미 좋아요를 눌렀을 경우
+        if (heartJPARepository.findStoresByUserId(user.getId()).contains(store)){
+            throw new IllegalArgumentException("이미 하트가 눌러진 상태입니다.");
+        }
+
+        //없을 경우에 repo에 저장
+        Heart heart = Heart.builder().user(user).store(store).build();
+        heartJPARepository.save(heart);
+    }
+
+    @Transactional
+    public void deleteHeartToStore(Long storeId, String email){
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
+        Store store = storeJPARepository.findById(storeId).orElseThrow(() -> new IllegalArgumentException("해당 가게를 찾을 수 없습니다."));
+
+        //좋아요가 없을 경우 error
+        Heart heart = heartJPARepository.findHeartByUserId(user.getId()).orElseThrow(()-> new IllegalArgumentException("좋아요가 없습니다."));
+        //좋아요가 있을 경우 하트 삭제
+        heartJPARepository.delete(heart);
+    }
+
+
+    public HeartResponseDTO.FindAllLikeStoresDTO findStoresByUser(String email) {
+        User user= userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 회원을 찾을 수 없습니다."));
+        List<Store> stores=  heartJPARepository.findStoresByUserId(user.getId()).stream().toList();
+        return new HeartResponseDTO.FindAllLikeStoresDTO(user,stores);
+    }
+}


### PR DESCRIPTION
## 변경 요약
- 사용자는 자신이 원하는 음식점에 하트를 눌러 저장할 수 있습니다.


## 변경 사항
- 좋아요 기능 구현을 위한 heart_tb를 생성하였습니다.
- id, user_id, store_id 를 column으로 갖습니다.
- 음식점 상세 페이지에서 하트를 누르면 해당 음식점 id와 UserPrincipal을 통해 유저 id를 확인하고 heart_tb에 추가해줍니다.
- PUT 요청을 사용합니다.


## 테스트 방법
PUT /stores/{id}/like

## 추가 정보
- 삭제 기능은 구현 중입니다.
- 좋아요 누른 음식점 보기 기능은 정상작동하는 것을 확인하였습니다. 본래 mypage/myLike url로 연결되어야 하기 때문에 나중에 User 패키지 안에 구현할것입니다.




