### PR TITLE
Renewal of Cursor-Based Pagination

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/chatgpt/schedule/ScheduledTasks.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/chatgpt/schedule/ScheduledTasks.java
@@ -34,7 +34,7 @@ public class ScheduledTasks {
     @Scheduled(cron = "0 40 * * * SUN")
     public void getReviewSummarysFromChatGptApi() {
 
-        List<GptResponse> gptResponses = storeService.findAll().stream()
+        List<GptResponse> gptResponses = storeService.findAllForGpt().stream()
                 .filter(store -> getReviewDifference(store) >= API_CALL_TRIGGER)
                 .map(store -> gptService.generateReviewSummarys(store.getStoreId()))
                 .flatMap(List::stream)

--- a/matgpt/src/main/java/com/ktc/matgpt/store/Store.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/Store.java
@@ -1,13 +1,11 @@
 package com.ktc.matgpt.store;
 
-
 import com.ktc.matgpt.store.entity.SubCategory;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
 
 @Entity
 @Builder
@@ -74,5 +72,14 @@ public class Store {
         this.numsOfReview--;
     }
 
-
+    public double calculateDistanceFromLatLon(Double latitude, Double longitude) {
+        final double EARTH_RADIUS = 6371.0;
+        double latDistance = Math.toRadians(latitude - this.latitude);
+        double lonDistance = Math.toRadians(longitude - this.longitude);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(this.latitude)) * Math.cos(Math.toRadians(latitude))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS * c; // 결과는 킬로미터 단위로 반환.
+    }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreJPARepository.java
@@ -1,49 +1,78 @@
 package com.ktc.matgpt.store;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface StoreJPARepository extends JpaRepository<Store,Long> {
 
-    Optional<Store> findById(Long id);
+    @Query(value = "SELECT s FROM Store s JOIN FETCH s.subCategory sc JOIN FETCH sc.category c WHERE s.id = :id")
+    Optional<Store> findById(@Param("id")Long id);
 
     //거리안의 음식점 marker 가져오기
-    @Query(value ="SELECT * FROM store_tb WHERE latitude < :maxLat AND latitude > :minLat AND longitude < :maxLon AND longitude > :minLon  ", nativeQuery = true)
+    @Query(value ="SELECT * FROM store_tb WHERE latitude < :maxLat AND latitude > :minLat AND longitude < :maxLon AND longitude > :minLon", nativeQuery = true)
     List<Store> findMarkers(@Param("maxLat")double maxLat, @Param("maxLon")double maxLon, @Param("minLat")double minLat, @Param("minLon")double minLon);
 
+    // mysql에서는 st_distance_sphere 함수를 사용가능하지만, 배포환경인 mariadb와 h2에서는 사용 불가하므로, 공식을 통해 거리 가져오기
     //사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기
-    @Query(value ="SELECT *,ST_Distance_Sphere(POINT(:longitude, :latitude),POINT(longitude, latitude)) AS distance FROM store_tb ", nativeQuery = true)
-    List<Store> findNearestStoresWithDistance(double latitude, double longitude);
+    @Query(value = "WITH DistanceCTE AS (" +
+            "SELECT s.*, " +
+            "6371 * ACOS(" +
+            "COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
+            "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
+            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))" +
+            ") AS distance FROM store_tb s)" +
+            "SELECT * FROM DistanceCTE " +
+            "WHERE (distance > :cursor OR (distance = :cursor AND id < :lastid)) " +
+            "ORDER BY distance ASC, id DESC",
+            nativeQuery = true)
+    List<Store> findNearestStoresWithDistance(@Param("latitude")double latitude, @Param("longitude")double longitude, @Param("cursor")Double cursor, @Param("lastid")Long lastId, Pageable pageable);
 
+    //사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기
+    @Query(value = "WITH DistanceCTE AS (" +
+            "SELECT s.*, " +
+            "6371 * ACOS(" +
+            "COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
+            "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
+            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))" +
+            ") AS distance FROM store_tb s)" +
+            "SELECT * FROM DistanceCTE " +
+            "ORDER BY distance ASC, id DESC",
+            nativeQuery = true)
+    List<Store> findNearestStoresWithDistance(@Param("latitude")double latitude, @Param("longitude")double longitude, Pageable pageable);
 
     //별점 높은 순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.ratingAvg DESC , s.id")
-    List<Store> findAllByStar(@Param("search")String search,Pageable page);
+    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.ratingAvg DESC")
+    List<Store> findAllByStar(@Param("search")String search, Pageable pageable);
 
     //별점 높은 순으로 가게 불러오기 with cursor id
-    @Query("SELECT s FROM Store s WHERE s.id < :id AND s.name LIKE %:search% ORDER by s.ratingAvg DESC, s.id ")
-    List<Store> findAllByStarLessThanIdDesc(@Param("search")String search,@Param("id")Long id, Pageable page);
-
+    @Query("SELECT s FROM Store s " +
+            "WHERE s.name LIKE %:search% AND (s.ratingAvg < :cursor OR (s.ratingAvg = :cursor AND s.id < :lastid))" +
+            "ORDER by s.ratingAvg DESC, s.id DESC")
+    List<Store> findAllByStarLessThanIdDesc(@Param("search")String search, @Param("cursor")Long cursor, @Param("lastid")Long lastId, Pageable pageable);
 
     //id 내림차순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER by s.id DESC ")
-    List<Store> findAllById(@Param("search")String search,Pageable page);
+    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER by s.id DESC")
+    List<Store> findAllById(@Param("search")String search, Pageable pageable);
 
     //id 내림차순으로 가게 불러오기 with cursor id
-    @Query("SELECT s FROM Store s WHERE s.id < :id AND s.name LIKE %:search% ORDER by  s.id  ")
-    List<Store> findByIdLessThanOrderByIdDesc(@Param("search")String search,Long id, Pageable page);
+    @Query("SELECT s FROM Store s WHERE s.id < :cursor AND s.name LIKE %:search% ORDER by s.id DESC")
+    List<Store> findByIdLessThanOrderByIdDesc(@Param("search")String search, @Param("cursor")Long cursor, Pageable pageable);
 
     //리뷰 많은 순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.numsOfReview DESC, s.id ")
-    List<Store> findAllByReviews(@Param("search")String search,  Pageable page);
+    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.numsOfReview DESC, s.id")
+    List<Store> findAllByReviews(@Param("search")String search, Pageable pageable);
 
     //리뷰 많은 순으로 가게 불러오기 with cursor id
-    @Query("SELECT s FROM Store s WHERE s.id < :id AND s.name LIKE %:search% ORDER by s.numsOfReview DESC, s.id  ")
-    List<Store> findAllByReviewsLessThanIdDesc(@Param("search")String search,@Param("id")Long id, Pageable page);
+    @Query("SELECT s " +
+            "FROM Store s " +
+            "WHERE s.name LIKE %:search% AND (s.numsOfReview < :cursor OR (s.numsOfReview = :cursor AND s.id < :lastId))" +
+            "ORDER BY s.numsOfReview DESC, s.id DESC")
+    List<Store> findAllByReviewsLessThanIdDesc(@Param("search")String search, @Param("cursor")int cursor, @Param("lastId")Long lastId, Pageable pageable);
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreJPARepository.java
@@ -17,7 +17,7 @@ public interface StoreJPARepository extends JpaRepository<Store,Long> {
 
     //거리안의 음식점 marker 가져오기
     @Query(value ="SELECT * FROM store_tb WHERE latitude < :maxLat AND latitude > :minLat AND longitude < :maxLon AND longitude > :minLon", nativeQuery = true)
-    List<Store> findMarkers(@Param("maxLat")double maxLat, @Param("maxLon")double maxLon, @Param("minLat")double minLat, @Param("minLon")double minLon);
+    List<Store> findAllWithinLatLonBoundaries(@Param("maxLat")double maxLat, @Param("maxLon")double maxLon, @Param("minLat")double minLat, @Param("minLon")double minLon);
 
     // mysql에서는 st_distance_sphere 함수를 사용가능하지만, 배포환경인 mariadb와 h2에서는 사용 불가하므로, 공식을 통해 거리 가져오기
     //사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기
@@ -32,7 +32,7 @@ public interface StoreJPARepository extends JpaRepository<Store,Long> {
             "WHERE (distance > :cursor OR (distance = :cursor AND id < :lastid)) " +
             "ORDER BY distance ASC, id DESC",
             nativeQuery = true)
-    List<Store> findNearestStoresWithDistance(@Param("latitude")double latitude, @Param("longitude")double longitude, @Param("cursor")Double cursor, @Param("lastid")Long lastId, Pageable pageable);
+    List<Store> findAllByNearestAndDistanceLessThanCursor(@Param("latitude")double latitude, @Param("longitude")double longitude, @Param("cursor")Double cursor, @Param("lastid")Long lastId, Pageable pageable);
 
     //사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기
     @Query(value = "WITH DistanceCTE AS (" +
@@ -45,34 +45,34 @@ public interface StoreJPARepository extends JpaRepository<Store,Long> {
             "SELECT * FROM DistanceCTE " +
             "ORDER BY distance ASC, id DESC",
             nativeQuery = true)
-    List<Store> findNearestStoresWithDistance(@Param("latitude")double latitude, @Param("longitude")double longitude, Pageable pageable);
+    List<Store> findAllByNearest(@Param("latitude")double latitude, @Param("longitude")double longitude, Pageable pageable);
 
-    //별점 높은 순으로 가게 불러오기
+    // 별점 높은 순으로 가게 불러오기
     @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.ratingAvg DESC")
-    List<Store> findAllByStar(@Param("search")String search, Pageable pageable);
+    List<Store> findAllBySearchOrderByRatingDesc(@Param("search")String search, Pageable pageable);
 
-    //별점 높은 순으로 가게 불러오기 with cursor id
+    // 별점 높은 순으로 가게 불러오기 with cursor id
     @Query("SELECT s FROM Store s " +
             "WHERE s.name LIKE %:search% AND (s.ratingAvg < :cursor OR (s.ratingAvg = :cursor AND s.id < :lastid))" +
             "ORDER by s.ratingAvg DESC, s.id DESC")
-    List<Store> findAllByStarLessThanIdDesc(@Param("search")String search, @Param("cursor")Long cursor, @Param("lastid")Long lastId, Pageable pageable);
+    List<Store> findAllBySearchAndRatingLessThanCursor(@Param("search")String search, @Param("cursor")Long cursor, @Param("lastid")Long lastId, Pageable pageable);
 
-    //id 내림차순으로 가게 불러오기
+    // id 내림차순으로 가게 불러오기
     @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER by s.id DESC")
-    List<Store> findAllById(@Param("search")String search, Pageable pageable);
+    List<Store> findAllBySearchOrderByIdDesc(@Param("search")String search, Pageable pageable);
 
-    //id 내림차순으로 가게 불러오기 with cursor id
+    // id 내림차순으로 가게 불러오기 with cursor id
     @Query("SELECT s FROM Store s WHERE s.id < :cursor AND s.name LIKE %:search% ORDER by s.id DESC")
-    List<Store> findByIdLessThanOrderByIdDesc(@Param("search")String search, @Param("cursor")Long cursor, Pageable pageable);
+    List<Store> findAllBySearchAndIdLessThanCursor(@Param("search")String search, @Param("cursor")Long cursor, Pageable pageable);
 
-    //리뷰 많은 순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.numsOfReview DESC, s.id")
-    List<Store> findAllByReviews(@Param("search")String search, Pageable pageable);
+    // 리뷰 많은 순으로 가게 불러오기
+    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.numsOfReview DESC, s.id DESC")
+    List<Store> findAllBySearchOrderByNumsOfReviewDesc(@Param("search")String search, Pageable pageable);
 
-    //리뷰 많은 순으로 가게 불러오기 with cursor id
+    // 리뷰 많은 순으로 가게 불러오기 with cursor id
     @Query("SELECT s " +
             "FROM Store s " +
             "WHERE s.name LIKE %:search% AND (s.numsOfReview < :cursor OR (s.numsOfReview = :cursor AND s.id < :lastId))" +
             "ORDER BY s.numsOfReview DESC, s.id DESC")
-    List<Store> findAllByReviewsLessThanIdDesc(@Param("search")String search, @Param("cursor")int cursor, @Param("lastId")Long lastId, Pageable pageable);
+    List<Store> findAllBySearchAndNumsOfReviewLessThanCursor(@Param("search")String search, @Param("cursor")int cursor, @Param("lastId")Long lastId, Pageable pageable);
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreResponse.java
@@ -1,8 +1,7 @@
 package com.ktc.matgpt.store;
+
 import com.ktc.matgpt.store.entity.Category;
 import com.ktc.matgpt.store.entity.SubCategory;
-import jakarta.validation.constraints.Null;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -78,7 +77,6 @@ public class StoreResponse {
 
         private Long storeId;
         private String storeName;
-        private Category category;
         private SubCategory subCategory;
         private String phoneNumber;
         private String address;
@@ -92,7 +90,6 @@ public class StoreResponse {
         public FindByIdStoreDTO(Store store) {
             this.storeId = store.getId();
             this.storeName = store.getName();
-            this.category = store.getSubCategory().getCategory();
             this.subCategory = store.getSubCategory();
             this.phoneNumber = store.getPhoneNumber();
             this.address = store.getAddress();

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreRestController.java
@@ -1,13 +1,11 @@
 package com.ktc.matgpt.store;
 
-
-
 import com.ktc.matgpt.food.Food;
 import com.ktc.matgpt.food.FoodService;
 import com.ktc.matgpt.security.UserPrincipal;
 import com.ktc.matgpt.utils.ApiUtils;
+import com.ktc.matgpt.utils.PageResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -25,81 +23,79 @@ public class StoreRestController {
 
 
     //마커 찍는 stores 보내주기
-    @GetMapping("/")
-    public ResponseEntity<?> MarkerStores(
-                                          @RequestParam(value ="maxlat") double maxLat ,
+    @GetMapping("")
+    public ResponseEntity<?> markerStores(@RequestParam(value = "maxlat") double maxLat ,
                                           @RequestParam(value = "maxlon") double maxLon ,
-                                          @RequestParam(value ="minlat") double minLat ,
+                                          @RequestParam(value = "minlat") double minLat ,
                                           @RequestParam(value = "minlon") double minLon) {
-        List<StoreResponse.MarkerStoresDTO> responseDTOs = storeService.findAllMarkers(maxLat,maxLon,minLat,minLon);
+        List<StoreResponse.MarkerStoresDTO> responseDTOs = storeService.findAllMarkers(maxLat, maxLon, minLat, minLon);
         ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
         return ResponseEntity.ok(apiResult);
     }
-
 
     //사용자 거리와 가까운 순으로 불러오기
+    // TODO : 커서 기반 페이지네이션
     @GetMapping("/all")
-    public ResponseEntity<?> findAll(@RequestParam(value ="lati") double latitude ,
+    public ResponseEntity<?> findAll(@RequestParam(value = "lati") double latitude ,
                                      @RequestParam(value = "longi") double longitude ,
-                                     @RequestParam(value = "sort", defaultValue = "id") String sort,
-                                     @RequestParam(value = "cursor", defaultValue = "6") Long cursor) {
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findAllByDistance(latitude,longitude);
+                                     @RequestParam(value = "cursor", required = false, defaultValue = "-1.0") Double cursor,
+                                     @RequestParam(value = "lastid", required = false) Long lastId) {
+        PageResponse<Double, StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findAllByDistance(latitude, longitude, cursor, lastId, PAGE_DEFAULT_SIZE);
         ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
         return ResponseEntity.ok(apiResult);
     }
+
     //음식점 검색
     @GetMapping("/search")
-    public ResponseEntity<?> Search( @RequestParam(value ="lati") double latitude ,
-                                     @RequestParam(value = "longi") double longitude ,
-                                     @RequestParam(value = "sort", defaultValue = "id") String sort,
-                                     @RequestParam(value = "cursor", defaultValue = "6") Long cursor,
-                                     @RequestParam(value="q") String searchQuery ) {
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findBySearch(searchQuery,sort,cursor, PageRequest.of(0, PAGE_DEFAULT_SIZE));
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
+    public ResponseEntity<?> search(@RequestParam(value = "sort", defaultValue = "id") String sort,
+                                    @RequestParam(value = "cursor", required = false, defaultValue = "-1") Long cursor,
+                                    @RequestParam(value = "lastid", required = false) Long lastId,
+                                    @RequestParam(value= "q") String searchQuery ) {
+        PageResponse<?, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findBySearch(searchQuery, cursor, lastId, PAGE_DEFAULT_SIZE, sort);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
         return ResponseEntity.ok(apiResult);
     }
 
     //인기 많은 음식점 - 리뷰 갯수 순
     @GetMapping("/popular")
-    public ResponseEntity<?> findAllPopular(@RequestParam(value = "cursor", defaultValue = "6") Long cursor) {
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findAllByPopular(cursor, PageRequest.of(0, PAGE_DEFAULT_SIZE));
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
+    public ResponseEntity<?> findAllByPopular(@RequestParam(value = "cursor", required = false, defaultValue = "-1") Integer cursor,
+                                              @RequestParam(value = "lastid", required = false) Long lastId) {
+        PageResponse<Integer, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findAllByPopular(cursor, lastId, PAGE_DEFAULT_SIZE);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
         return ResponseEntity.ok(apiResult);
     }
 
-    //최근 리뷰가 달린 음식점
-    @GetMapping("/recent")
-    public ResponseEntity<?> findAllRecent(@RequestParam(value = "cursor", defaultValue = "6") Long cursor) {
-        //리뷰에서 가져와야함
-        return ResponseEntity.ok(null);
-    }
+    // 최근 리뷰가 달린 음식점
+//    @GetMapping("/recent-review")
+//    public ResponseEntity<?> findAllByRecentReviews(@RequestParam(value = "cursor", required = false) LocalDateTime cursor,
+//                                           @RequestParam(value = "lastid", required = false) Long lastId) {
+//        PageResponse<LocalDateTime, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findAllByRecentReviews(cursor, lastId, PAGE_DEFAULT_SIZE);
+//        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
+//        return ResponseEntity.ok(apiResult);
+//    }
 
     //비슷한 사용자들이 좋아하는 음식점
     @GetMapping("/similar")
-    public ResponseEntity<?> findAllSimilar(@RequestParam(value = "cursor", defaultValue = "6") Long cursor  ,@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findSimilarStores(userPrincipal.getEmail(),cursor, PageRequest.of(0, PAGE_DEFAULT_SIZE));
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
+    public ResponseEntity<?> findAllBySimilar(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                              @RequestParam(value = "cursor", required = false, defaultValue = "-1") Long cursor) {
+        PageResponse<Long, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findSimilarStores(userPrincipal.getEmail(), cursor, PAGE_DEFAULT_SIZE);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
         return ResponseEntity.ok(apiResult);
     }
 
-
-
-
-
-
-    @GetMapping("/stores/{id}")
-    public ResponseEntity<?> findById(@PathVariable(value = "id", required = true) Long id) {
-        StoreResponse.FindByIdStoreDTO responseDTO = storeService.getStoreDtoById(id);
+    @GetMapping("/{storeId}")
+    public ResponseEntity<?> findById(@PathVariable(value = "storeId") Long storeId) {
+        StoreResponse.FindByIdStoreDTO responseDTO = storeService.getStoreDtoById(storeId);
         ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTO);
         return ResponseEntity.ok(apiResult);
     }
 
     // 검색 기록을 통해 해당 음식점에서 최근 검색된 음식 리스트를 반환하는 로직
     // 예시로는 단순히 최근에 생성된 음식을 반환합니다.
+    // TODO : 오류 해결
     @GetMapping("/{storeId}/recentlySearchedFoods")
     public ResponseEntity<List<Food>> getRecentlySearchedFoodsByStore(@PathVariable Long storeId) {
         List<Food> recentlySearchedFoods = foodService.getRecentlySearchedFoodsByStore(storeId);
         return ResponseEntity.ok(recentlySearchedFoods);
     }
-
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreService.java
@@ -1,15 +1,12 @@
 package com.ktc.matgpt.store;
 
-
 import com.ktc.matgpt.exception.CustomException;
 import com.ktc.matgpt.exception.ErrorCode;
-import com.ktc.matgpt.like.likeStore.LikeStore;
 import com.ktc.matgpt.like.likeStore.LikeStoreJPARepository;
-import com.ktc.matgpt.user.entity.AgeGroup;
-import com.ktc.matgpt.user.entity.Gender;
 import com.ktc.matgpt.user.entity.User;
-import com.ktc.matgpt.user.repository.UserRepository;
 import com.ktc.matgpt.user.service.UserService;
+import com.ktc.matgpt.utils.CursorRequest;
+import com.ktc.matgpt.utils.PageResponse;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -19,68 +16,51 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
-import java.util.stream.Collectors;
+import java.util.function.Function;
 
 
 @RequiredArgsConstructor
 @Service
 public class StoreService {
 
-    private final StoreJPARepository storeJPARepository;
     private final UserService userService;
-    private final EntityManager entityManager;
-    private final UserRepository userRepository;
+    private final StoreJPARepository storeJPARepository;
     private final LikeStoreJPARepository likeStoreJPARepository;
+    private final EntityManager entityManager;
 
-    //마커 표시할 음식점 보기
+    // 마커 표시할 음식점 보기
     @Transactional(readOnly = true)
-    public List<StoreResponse.MarkerStoresDTO> findAllMarkers(double maxLatitude, double maxLongitude,double minLatitude, double minLongitude) {
-
-        List<Store> stores = storeJPARepository.findMarkers(maxLatitude,maxLongitude,minLatitude,minLongitude);
-
-        List<StoreResponse.MarkerStoresDTO> responseDTOs = stores.stream()
-                .map(s -> new StoreResponse.MarkerStoresDTO(s))
-                .collect(Collectors.toList());
-        return responseDTOs;
+    public List<StoreResponse.MarkerStoresDTO> findAllMarkers(double maxLat, double maxLon, double minLat, double minLon) {
+        List<Store> stores = storeJPARepository.findMarkers(maxLat, maxLon, minLat, minLon);
+        return stores.stream()
+                .map(StoreResponse.MarkerStoresDTO::new)
+                .toList();
     }
 
-
-    //사용자에게 가까운 순으로 보기
+    // 사용자에게 가까운 순으로 보기 + 커서 기반 페이지네이션
     @Transactional(readOnly = true)
-    public List<StoreResponse.FindAllStoreDTO> findAllByDistance(double latitude, double longitude) {
-        List<Store> stores = storeJPARepository.findNearestStoresWithDistance(latitude,longitude);
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = stores.stream()
-                .map(s -> new StoreResponse.FindAllStoreDTO(s))
-                .collect(Collectors.toList());
-        return responseDTOs;
+    public PageResponse<Double, StoreResponse.FindAllStoreDTO> findAllByDistance(double latitude, double longitude, Double cursor, Long lastId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        List<Store> stores = getStoreListByDistance(latitude, longitude, cursor, lastId, pageable);
+        return findAllStores(store -> store.calculateDistanceFromLatLon(latitude, longitude), stores, size);
     }
 
-    //인기 많은 음식점 보기 (리뷰많은순정렬)
+    // 인기 많은 음식점 보기 (리뷰많은순정렬)
     @Transactional(readOnly = true)
-    public List<StoreResponse.FindAllStoreDTO> findAllByPopular(Long cursor, Pageable pageable) {
-
-        List<Store> stores =  getStoreListByReviews(cursor,pageable,"");
-
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = stores.stream()
-                .map(s -> new StoreResponse.FindAllStoreDTO(s))
-                .collect(Collectors.toList());
-        return responseDTOs;
+    public PageResponse<Integer, StoreResponse.FindAllStoreDTO> findAllByPopular(Integer cursor, Long lastId, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+        List<Store> stores = getStoreListByReviews("", cursor, lastId, pageable);
+        return findAllStores(Store::getNumsOfReview, stores, size);
     }
 
     //비슷한 사용자들이 좋아하는 음식점 보기
     //TODO : 예외처리 해주기
     @Transactional(readOnly = true)
-    public List<StoreResponse.FindAllStoreDTO> findSimilarStores(String email, Long cursor, Pageable page) {
+    public PageResponse<Long, StoreResponse.FindAllStoreDTO> findSimilarStores(String email, Long cursor, int size) {
         User user = userService.findByEmail(email);
-        AgeGroup ageGroup = user.getAgeGroup();
-        Gender gender = user.getGender();
 
         //사용자와 나이와 성별이 같은 다른 사용자들 찾기
-        List<User> userList =  userRepository.findAll().stream()
-                .filter(u -> u.getAgeGroup().equals(ageGroup))
-                .filter(u -> u.getGender().equals(gender))
-                .collect(Collectors.toList());
-
+        List<User> userList =  userService.findByAgeGroupAndGender(user.getAgeGroup(), user.getGender());
 
         //다른 사용자들이 좋아요 누른 음식점 list counting
         Map<Store,Integer> storeList = new HashMap<>();
@@ -101,68 +81,60 @@ public class StoreService {
         List<Store> stores = new ArrayList<>(storeList.keySet());
         Collections.sort(stores,(v1,v2) -> (storeList.get(v2).compareTo(storeList.get(v1))));
 
-
-        //DTO로 response해주기
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = stores.stream()
-                .map(s -> new StoreResponse.FindAllStoreDTO(s))
-                .collect(Collectors.toList());
-
-        return responseDTOs;
+        return findAllStores(Store::getId, stores, size);
     }
 
-
-    //음식점 검색
+    // 음식점 검색
     @Transactional(readOnly = true)
-    public  List<StoreResponse.FindAllStoreDTO> findBySearch(String searchQuery,String sort, Long cursor, Pageable pageable) {
+    public PageResponse<? extends Comparable<?>, StoreResponse.FindAllStoreDTO> findBySearch(String search, Long cursor, Long lastId, int size, String sort) {
+        Pageable pageable = PageRequest.of(0, size);
+        List<Store> stores;
+        switch (sort) {
+            case "id" -> { // 높을수록 우선순위
+                stores = getStoreListById(search, cursor, pageable);
+                return findAllStores(Store::getId, stores, size);
+            }
+            case "rating" -> { // 높을수록 우선순위
+                stores = getStoreListByStar(search, cursor, lastId, pageable);
+                return findAllStores(Store::getRatingAvg, stores, size);
+            }
+            case "review" -> { // 높을수록 우선순위
+                stores = getStoreListByReviews(search, Math.toIntExact(cursor), lastId, pageable);
+                return findAllStores(Store::getNumsOfReview, stores, size);
+            }
+            default -> {
+                return new PageResponse<>(new CursorRequest<>(null, null, size), List.of());
+            }
+        }
+    }
 
-
-        List<Store> stores = null;
-        if (sort.equals("id")){
-            stores = getStoreListById(cursor,pageable,searchQuery);
-        } else if ( sort.equals("rating")) {
-            stores = getStoreListByStar(cursor,pageable,searchQuery);
-        } else if ( sort.equals("review")) {
-            stores = getStoreListByReviews(cursor,pageable,searchQuery);
+    @Transactional(readOnly = true)
+    public <T extends Comparable<T>> PageResponse<T, StoreResponse.FindAllStoreDTO> findAllStores(Function<Store, T> cursorExtractor, List<Store> stores, int size) {
+        if (stores.isEmpty()) {
+            return new PageResponse<>(new CursorRequest<>(null, null, size), List.of());
         }
 
-        List<StoreResponse.FindAllStoreDTO> responseDTOs = stores.stream()
-                .map(s -> new StoreResponse.FindAllStoreDTO(s))
-                .collect(Collectors.toList());
-        return responseDTOs;
+        List<StoreResponse.FindAllStoreDTO> findAllStoreDTOS = stores.stream()
+                .map(StoreResponse.FindAllStoreDTO::new)
+                .toList();
+
+        Store lastStore = stores.get(stores.size() - 1);
+        T nextCursor = cursorExtractor.apply(lastStore);
+        Long nextId = lastStore.getId();
+
+        return new PageResponse<>(new CursorRequest<>(nextCursor, nextId, size), findAllStoreDTOS);
     }
 
-    public List<StoreResponse.FindAllDTO> findAll() {
+    public List<StoreResponse.FindAllDTO> findAllForGpt() {
         return storeJPARepository.findAll().stream()
                 .map(StoreResponse.FindAllDTO::new)
                 .toList();
     }
 
-
-    private List<Store> getStoreListById(Long id, Pageable page , String search) {
-        return id.equals(0L)
-                ? storeJPARepository.findAllById(search,page)
-                : storeJPARepository.findByIdLessThanOrderByIdDesc(search,id,page);
-
-    }
-    private List<Store> getStoreListByStar(Long id, Pageable page, String search) {
-        return id.equals(0L)
-                ? storeJPARepository.findAllByStar(search,page)
-                : storeJPARepository.findAllByStarLessThanIdDesc(search,id,page);
-    }
-
-    private List<Store> getStoreListByReviews(Long id, Pageable page, String search) {
-        return id.equals(0L)
-                ? storeJPARepository.findAllByReviews(search,page)
-                : storeJPARepository.findAllByReviewsLessThanIdDesc(search,id,page);
-    }
-
-
-
     public Store findById(Long id) {
         return storeJPARepository.findById(id).orElseThrow(
                 () -> new CustomException(ErrorCode.STORE_NOT_FOUND));
     }
-
 
     public StoreResponse.FindByIdStoreDTO getStoreDtoById(Long id) {
         Store storePS = storeJPARepository.findById(id).orElseThrow(
@@ -183,5 +155,27 @@ public class StoreService {
         }
     }
 
+    private List<Store> getStoreListById(String search, Long cursor, Pageable pageable) {
+        return cursor == -1
+                ? storeJPARepository.findAllById(search, pageable)
+                : storeJPARepository.findByIdLessThanOrderByIdDesc(search, cursor, pageable);
+    }
 
+    private List<Store> getStoreListByStar(String search, Long cursor, Long lastId, Pageable pageable) {
+        return cursor == -1
+                ? storeJPARepository.findAllByStar(search, pageable)
+                : storeJPARepository.findAllByStarLessThanIdDesc(search,cursor, lastId, pageable);
+    }
+
+    private List<Store> getStoreListByReviews(String search, Integer cursor, Long lastId, Pageable pageable) {
+        return cursor == -1
+            ? storeJPARepository.findAllByReviews(search, pageable)
+            : storeJPARepository.findAllByReviewsLessThanIdDesc(search, cursor, lastId, pageable);
+    }
+
+    private List<Store> getStoreListByDistance(double latitude, double longitude, Double cursor, Long lastId, Pageable pageable) {
+        return cursor == -1.0
+                ? storeJPARepository.findNearestStoresWithDistance(latitude, longitude, pageable)
+                : storeJPARepository.findNearestStoresWithDistance(latitude, longitude, cursor, lastId, pageable);
+    }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreService.java
@@ -31,7 +31,7 @@ public class StoreService {
     // 마커 표시할 음식점 보기
     @Transactional(readOnly = true)
     public List<StoreResponse.MarkerStoresDTO> findAllMarkers(double maxLat, double maxLon, double minLat, double minLon) {
-        List<Store> stores = storeJPARepository.findMarkers(maxLat, maxLon, minLat, minLon);
+        List<Store> stores = storeJPARepository.findAllWithinLatLonBoundaries(maxLat, maxLon, minLat, minLon);
         return stores.stream()
                 .map(StoreResponse.MarkerStoresDTO::new)
                 .toList();
@@ -157,25 +157,25 @@ public class StoreService {
 
     private List<Store> getStoreListById(String search, Long cursor, Pageable pageable) {
         return cursor == -1
-                ? storeJPARepository.findAllById(search, pageable)
-                : storeJPARepository.findByIdLessThanOrderByIdDesc(search, cursor, pageable);
+                ? storeJPARepository.findAllBySearchOrderByIdDesc(search, pageable)
+                : storeJPARepository.findAllBySearchAndIdLessThanCursor(search, cursor, pageable);
     }
 
     private List<Store> getStoreListByStar(String search, Long cursor, Long lastId, Pageable pageable) {
         return cursor == -1
-                ? storeJPARepository.findAllByStar(search, pageable)
-                : storeJPARepository.findAllByStarLessThanIdDesc(search,cursor, lastId, pageable);
+                ? storeJPARepository.findAllBySearchOrderByRatingDesc(search, pageable)
+                : storeJPARepository.findAllBySearchAndRatingLessThanCursor(search,cursor, lastId, pageable);
     }
 
     private List<Store> getStoreListByReviews(String search, Integer cursor, Long lastId, Pageable pageable) {
         return cursor == -1
-            ? storeJPARepository.findAllByReviews(search, pageable)
-            : storeJPARepository.findAllByReviewsLessThanIdDesc(search, cursor, lastId, pageable);
+            ? storeJPARepository.findAllBySearchOrderByNumsOfReviewDesc(search, pageable)
+            : storeJPARepository.findAllBySearchAndNumsOfReviewLessThanCursor(search, cursor, lastId, pageable);
     }
 
     private List<Store> getStoreListByDistance(double latitude, double longitude, Double cursor, Long lastId, Pageable pageable) {
         return cursor == -1.0
-                ? storeJPARepository.findNearestStoresWithDistance(latitude, longitude, pageable)
-                : storeJPARepository.findNearestStoresWithDistance(latitude, longitude, cursor, lastId, pageable);
+                ? storeJPARepository.findAllByNearest(latitude, longitude, pageable)
+                : storeJPARepository.findAllByNearestAndDistanceLessThanCursor(latitude, longitude, cursor, lastId, pageable);
     }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/user/repository/UserRepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/user/repository/UserRepository.java
@@ -1,15 +1,19 @@
 package com.ktc.matgpt.user.repository;
 
 
+import com.ktc.matgpt.user.entity.AgeGroup;
+import com.ktc.matgpt.user.entity.Gender;
 import com.ktc.matgpt.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    List<User> findAllByAgeGroupAndGender(AgeGroup ageGroup, Gender gender);
     Optional<User> findByEmail(String email);
     Boolean existsByEmail(String email);
 

--- a/matgpt/src/main/java/com/ktc/matgpt/user/service/UserService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.ktc.matgpt.user.service;
 
+import com.ktc.matgpt.user.entity.AgeGroup;
+import com.ktc.matgpt.user.entity.Gender;
 import com.ktc.matgpt.user.entity.User;
 import com.ktc.matgpt.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
@@ -28,6 +31,10 @@ public class UserService {
     public User getReferenceByEmail(String email) {
         // 실제 엔터티를 로드하지 않고, 프록시 객체를 반환
         return entityManager.getReference(User.class, findByEmail(email).getId());
+    }
+
+    public List<User> findByAgeGroupAndGender(AgeGroup ageGroup, Gender gender) {
+        return userRepository.findAllByAgeGroupAndGender(ageGroup, gender);
     }
 
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/utils/CursorRequest.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/utils/CursorRequest.java
@@ -1,0 +1,7 @@
+package com.ktc.matgpt.utils;
+
+public record CursorRequest<T> (
+        T nextCursor,
+        Long lastId,
+        int size
+) {}

--- a/matgpt/src/main/java/com/ktc/matgpt/utils/PageResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/utils/PageResponse.java
@@ -1,0 +1,8 @@
+package com.ktc.matgpt.utils;
+
+import java.util.List;
+
+public record PageResponse<T, U> (
+        CursorRequest<T> cursorRequest,
+        List<U> body
+){}


### PR DESCRIPTION
## 변경 요약
기존에 구현했던 커서 기반 페이지네이션의 동작을 수정했습니다.

## 변경 배경
- API 응답이 제대로 오지 않는 상황 발생
- 프론트로 Cursor에 대한 정보 제공 필요

## 변경 사항
- 커서기반 페이지네이션에 필요한 DTO를 정의했습니다. (CursorRequest, PageResponse)
- 커서기반 페이지네이션에서 응답이 제대로 되도록 수정했습니다.
- 기존의 코드를 리팩토링했습니다.
- 거리 순서 정렬을 위하여 위경도로 거리를 계산하는 메서드를 추가했습니다. 

## 테스트 방법
### <리뷰 많은순으로 잘 정렬되고, 마지막 cursor값과, cursor값이 중복되는 경우를 대비한 lastId 필드를 응답>
![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/24ac629d-b325-4386-915d-73d00b422d95)

### < id순으로 정렬도 잘 되는 모습>
![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/562be943-60c5-44ab-b6be-3dca4af03fee)

### < 거리순 정렬에서 nextCursor값으로 거리가 잘 들어오는 모습>
![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/f20099d8-8eb0-44d4-bb18-a312e84785b3)

### 검색어를 '이'라고 검색했을 때, 관련된 음식점 모두 제공
![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/ee029880-64a5-4d83-ba04-f6e5815b7c62)


## 추가 정보
StoreService에서 likeStoreSerivce를 주입하면 순환 참조 문제가 발생하여, likeStoreRepository를 주입했습니다.
### 해결방법
1. likeStore에서 storeService를 주입하지 않고, (store객체를 사용하는 것이 아닌, id값만을 사용)
2. 레이어 침범 상관없이 Repository 주입
3. Facade 패턴 사용하여 StoreFacadeService 생성해서 저기서 Store, likeStore 모두 주입받고 사용하기

### 시도 및 생각
1. id값만을 사용한다면... 연관관계가 끊어짐..
2. 레이어 침범 ㅠ
3. 새로운 서비스 생성으로 인해 코드의 큰 변경, 도메인의 명확한 서비스 제공 불가라고 생각합니다..

## TODO
### 1. 최근 리뷰가 달린 음식점
### 2. 검색 기록을 통해 해당 음식점에서 최근 검색된 음식 리스트를 반환하는 로직
2번 기능은 검색 기록을 가지고 있어야 하는데.. 사용자 행동을 트래킹하는 기능이 아직 없네요
