### PR TITLE
Update GptResponse Contents

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/chatgpt/controller/GptRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/chatgpt/controller/GptRestController.java
@@ -2,6 +2,7 @@ package com.ktc.matgpt.chatgpt.controller;
 
 import com.ktc.matgpt.chatgpt.dto.GptApiResponse;
 import com.ktc.matgpt.chatgpt.dto.GptResponse;
+import com.ktc.matgpt.chatgpt.dto.GptResponseDto;
 import com.ktc.matgpt.chatgpt.service.GptService;
 import com.ktc.matgpt.chatgpt.utils.UnixTimeConverter;
 import com.ktc.matgpt.security.UserPrincipal;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 @Slf4j
@@ -24,11 +26,10 @@ public class GptRestController {
 
     private final GptService gptService;
 
-    @GetMapping("/store/{storeId}/review/{summaryType}")
-    public ResponseEntity<?> getBestReviewSummary(@PathVariable(value="storeId") Long storeId,
-                                                  @PathVariable(value="summaryType") String summaryType) {
-        String content = gptService.findReviewSummaryByStoreIdAndSummaryType(storeId, summaryType);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(content);
+    @GetMapping("/store/{storeId}/review")
+    public ResponseEntity<?> getReviewSummarys(@PathVariable(value = "storeId") Long storeId) {
+        GptResponseDto<Map<String, String>> gptResponseDto = gptService.findReviewSummaryByStoreId(storeId);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(gptResponseDto);
         return ResponseEntity.ok().body(apiResult);
     }
 

--- a/matgpt/src/main/java/com/ktc/matgpt/chatgpt/dto/GptResponseDto.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/chatgpt/dto/GptResponseDto.java
@@ -1,0 +1,6 @@
+package com.ktc.matgpt.chatgpt.dto;
+
+public record GptResponseDto<T>(
+        boolean isExist,
+        T content
+) {}

--- a/matgpt/src/main/java/com/ktc/matgpt/chatgpt/schedule/ScheduledTasks.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/chatgpt/schedule/ScheduledTasks.java
@@ -31,7 +31,7 @@ public class ScheduledTasks {
      * chatGpt review Summary를 갱신합니다.
      */
     @Timer
-    @Scheduled(cron = "0 40 * * * SUN")
+    @Scheduled(cron = "0 0 4 * * SUN")
     public void getReviewSummarysFromChatGptApi() {
 
         List<GptResponse> gptResponses = storeService.findAllForGpt().stream()

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -180,8 +180,8 @@ public class ReviewService {
 
     public List<Review> findByStoreIdAndSummaryType(Long storeId, String summaryType, int limit) {
         Pageable pageable = switch (summaryType) {
-            case "BEST" -> PageRequest.of(0, limit, Sort.by(Sort.Order.desc("rating")));
-            case "WORST" -> PageRequest.of(0, limit, Sort.by(Sort.Order.asc("rating")));
+            case "best" -> PageRequest.of(0, limit, Sort.by(Sort.Order.desc("rating")));
+            case "worst" -> PageRequest.of(0, limit, Sort.by(Sort.Order.asc("rating")));
             default -> throw new IllegalArgumentException("Invalid summaryType: " + summaryType);
         };
 


### PR DESCRIPTION
## 변경 요약
GptResponse의 형식을 변경했습니다. 

## 변경 배경
- 프론트엔드 쪽에서 응답 내용을 변경해달라는 요청이 있었습니다.

## 변경 사항
기존에는 best/worst를 url로 요청해서 해당하는 content만 날아갔다면, 현재는 isExist 필드와, best/worst 모두 함께 날아갑니다.

![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/ac0d3d69-dd6c-476b-b6a5-faddb9410ad8)