### PR TITLE
리뷰 및 리뷰 좋아요 기능 보완

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewJPARepository.java
@@ -2,6 +2,8 @@ package com.ktc.matgpt.like.likeReview;
 
 import com.ktc.matgpt.review.entity.Review;
 import com.ktc.matgpt.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -18,4 +20,7 @@ public interface LikeReviewJPARepository extends JpaRepository<LikeReview, Long>
     void deleteAllByReviewId(Long reviewId);
 
     boolean existsByUserAndReview(User userRef, Review reviewRef);
+
+    @Query("select lr FROM LikeReview lr JOIN FETCH lr.review JOIN FETCH lr.user WHERE lr.user.id = :userId ORDER BY lr.id DESC")
+    Page<LikeReview> findAllByUserIdAndOrderByIdDesc(Long userId, Pageable page);
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewResponseDTO.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewResponseDTO.java
@@ -1,97 +1,51 @@
 package com.ktc.matgpt.like.likeReview;
 
 import com.ktc.matgpt.review.entity.Review;
-import com.ktc.matgpt.store.Store;
+import com.ktc.matgpt.user.entity.User;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
-// TODO: api 형식에 맞게 수정 필요
 public class LikeReviewResponseDTO {
-    List<FindLikeReviewDTO> reviews;
+
     @Getter @Setter
-    public static class FindLikeReviewDTO {
-        private Long id;
-        private double rating;
-        private String content;
-        private LocalDateTime createdAt;
-        private String storeImage;
-        private String storeName;
-        private int peopleCount;
-        private String reviewerName;
-        private String reviewerImage;
-
-        public FindLikeReviewDTO(Review review, String reviewerName, String reviewerImage){
-            this.id = review.getId();
-            this.rating = review.getRating();
-            this.content = review.getContent();
-            this.createdAt = review.getCreatedAt();
-            this.storeImage = review.getStore().getStoreImg();
-            this.storeName = review.getStore().getName();
-            this.peopleCount = review.getPeopleCount();
-            this.reviewerName = reviewerName;
-            this.reviewerImage = reviewerImage;
-          
-    @Getter
-    @Setter
-    public static class FindAllLikeReviewsDTO{
-
-        private List<LikeReviewResponseDTO.FindAllLikeReviewsDTO.ReviewDTO> reviewList;
-
-        public FindAllLikeReviewsDTO(User user, List<Review> reviewList){
-            this.reviewList = reviewList.stream()
-                    .map(review -> new ReviewDTO(review, user)) // Review와 User 객체 모두 전달
-                    .collect(Collectors.toList());
+    public static class FindLikeReviewsDTO {
+        List<LikeReviewDTO> reviews;
+        public FindLikeReviewsDTO(List<LikeReview> likeReviews) {
+            this.reviews = likeReviews.stream().map(
+                    likeReview -> {
+                        Review review = likeReview.getReview();
+                        User reviewer = likeReview.getUser();
+                        return new LikeReviewDTO(review, reviewer);
+                    }).collect(Collectors.toList());
         }
 
         @Getter @Setter
-        public class ReviewDTO{
-            private Long reviewId;
-            private String reviewContent;
+        public static class LikeReviewDTO {
+            private Long id;
             private double rating;
+            private String content;
+            private LocalDateTime createdAt;
+            private String storeImage;
+            private String storeName;
             private int peopleCount;
-            private int numOfLikes;
-            private StoreDTO store;
-            private ReviewerDTO reviewer;
+            private String reviewerName;
+            private String reviewerImage;
 
-            public ReviewDTO(Review review,User user){
-                this.reviewId = review.getId();
-                this.reviewContent = review.getContent();
+            public LikeReviewDTO(Review review, User reviewer){
+                this.id = review.getId();
                 this.rating = review.getRating();
+                this.content = review.getContent();
+                this.createdAt = review.getCreatedAt();
+                this.storeImage = review.getStore().getStoreImageUrl();
+                this.storeName = review.getStore().getName();
                 this.peopleCount = review.getPeopleCount();
-                this.numOfLikes = review.getRecommendCount();
-                this.store = new StoreDTO(review.getStore());
-                this.reviewer = new ReviewerDTO(user); // ReviewerDTO 초기화
+                this.reviewerName = reviewer.getName();
+                this.reviewerImage = reviewer.getProfileImageUrl();
             }
-
-            @Getter @Setter
-            public class StoreDTO{
-                private Long storeId;
-                private String storeName;
-                private String storeImage;
-
-                public StoreDTO(Store store){
-                    this.storeId = store.getId();
-                    this.storeName = store.getName();
-                    this.storeImage = store.getStoreImageUrl();
-                }
-            }
-
-            @Getter @Setter
-            public class ReviewerDTO{
-                private Long userId;
-                private String userName;
-                private String userProfileImage;
-
-                public ReviewerDTO(User user){
-                    this.userId = user.getId();
-                    this.userName = user.getName();
-                    this.userProfileImage = user.getProfileImageUrl();
-                }
-            }
-
         }
     }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewRestController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class LikeReviewRestController {
     private final LikeReviewService likeReviewService;
 
+    // 리뷰 좋아요 상태 전환하기 (좋아요 등록<->좋아요 취소)
     @PostMapping("reviews/{reviewId}/like")
     public ResponseEntity<?> toggleLikeForReview(@PathVariable Long reviewId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         boolean isLikeAdded = likeReviewService.toggleLikeForReview(reviewId, userPrincipal.getEmail());

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewJPARepository.java
@@ -24,16 +24,16 @@ public interface ReviewJPARepository extends JpaRepository<Review, Long> {
 
     @Query(nativeQuery = true, value =
             "SELECT * FROM review_tb r " +
-            "WHERE store_id = :storeId AND (rating < :cursorRating OR (rating = :cursorRating AND id < :cursorId)) " +
-            "ORDER BY rating DESC, id DESC " +
+            "WHERE store_id = :storeId AND (recommend_count < :cursorLikes OR (recommend_count= :cursorLikes AND id < :cursorId)) " +
+            "ORDER BY recommend_count DESC, id DESC " +
             "LIMIT :size")
-    List<Review> findAllByStoreIdAndOrderByRatingDesc(Long storeId, Long cursorId, double cursorRating, int size);
+    List<Review> findAllByStoreIdAndOrderByLikesDesc(Long storeId, Long cursorId, int cursorLikes, int size);
 
 
     @Query("select r FROM Review r JOIN FETCH r.store WHERE r.userId = :userId ORDER BY r.id DESC")
     Page<Review> findAllByUserIdAndOrderByIdDesc(Long userId, Pageable page);
 
-    @Query("SELECT r FROM Review r JOIN FETCH r.store WHERE r.userId = :userId ORDER BY r.rating DESC, r.id DESC")
-    Page<Review> findAllByUserIdAndOrderByRatingDesc(Long userId, Pageable page);
+    @Query("SELECT r FROM Review r JOIN FETCH r.store WHERE r.userId = :userId ORDER BY r.recommendCount DESC, r.id DESC")
+    Page<Review> findAllByUserIdAndOrderByLikesDesc(Long userId, Pageable page);
 
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewJPARepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ReviewJPARepository extends JpaRepository<Review, Long> {

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
@@ -66,9 +66,9 @@ public class ReviewRestController {
     public ResponseEntity<?> findAllByStoreId(@PathVariable Long storeId,
                                               @RequestParam(defaultValue = "latest") String sortBy,
                                               @RequestParam(defaultValue = "6") Long cursorId,
-                                              @RequestParam(defaultValue = "5.0") double cursorRating
+                                              @RequestParam(defaultValue = "1000") int cursorLikes
     ) {
-        List<ReviewResponse.FindAllByStoreIdDTO> responseDTOs = reviewService.findAllByStoreId(storeId, sortBy, cursorId, cursorRating);
+        List<ReviewResponse.FindAllByStoreIdDTO> responseDTOs = reviewService.findAllByStoreId(storeId, sortBy, cursorId, cursorLikes);
 
         ApiUtils.ApiResult<?> apiResult = ApiUtils.success(responseDTOs);
         return ResponseEntity.ok(apiResult);

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
@@ -28,10 +28,10 @@ public class ReviewRestController {
     private final ImageService imageService;
 
     // 첫 번째 단계: 리뷰 임시 저장 및 Presigned URL 반환
-    @PostMapping("/temp", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/temp", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiUtils.ApiResult<?>> createTemporaryReview(@PathVariable Long storeId,
                                                                        @RequestPart("data") ReviewRequest.SimpleCreateDTO requestDTO,
-                                                                       @RequestPart("images") List<MultipartFile> images,
+                                                                       @RequestPart(value = "images", required = false) List<MultipartFile> images,
                                                                        @AuthenticationPrincipal UserPrincipal userPrincipal) {
         try {
             //파일 검증

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -155,12 +155,11 @@ public class ReviewService {
         return new ReviewResponse.FindByReviewIdDTO(review, reviewerDTO, imageDTOs, relativeTime);
     }
 
-
-    public List<ReviewResponse.FindAllByStoreIdDTO> findAllByStoreId(Long storeId, String sortBy, Long cursorId, double cursorRating) {
+    public List<ReviewResponse.FindAllByStoreIdDTO> findAllByStoreId(Long storeId, String sortBy, Long cursorId, int cursorLikes) {
 
         List<Review> reviews = switch (sortBy) {
             case "latest" -> reviewJPARepository.findAllByStoreIdAndOrderByIdDesc(storeId, cursorId, DEFAULT_PAGE_SIZE);
-            case "rating" -> reviewJPARepository.findAllByStoreIdAndOrderByRatingDesc(storeId, cursorId, cursorRating, DEFAULT_PAGE_SIZE);
+            case "likes" -> reviewJPARepository.findAllByStoreIdAndOrderByLikesDesc(storeId, cursorId, cursorLikes, DEFAULT_PAGE_SIZE);
             default -> throw new IllegalArgumentException("Invalid sorting: " + sortBy);
         };
 
@@ -195,7 +194,7 @@ public class ReviewService {
     public ReviewResponse.FindPageByUserIdDTO findAllByUserId(Long userId, String sortBy, int pageNum) {
         Page<Review> reviews = switch (sortBy) {
             case "latest" -> reviewJPARepository.findAllByUserIdAndOrderByIdDesc(userId, PageRequest.of(pageNum-1, DEFAULT_PAGE_SIZE));
-            case "rating" -> reviewJPARepository.findAllByUserIdAndOrderByRatingDesc(userId, PageRequest.of(pageNum-1, DEFAULT_PAGE_SIZE));
+            case "likes" -> reviewJPARepository.findAllByUserIdAndOrderByLikesDesc(userId, PageRequest.of(pageNum-1, DEFAULT_PAGE_SIZE));
             default -> throw new IllegalArgumentException("Invalid sorting: " + sortBy);
         };
 

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -7,7 +7,6 @@ import com.ktc.matgpt.food.Food;
 import com.ktc.matgpt.food.FoodService;
 import com.ktc.matgpt.image.Image;
 import com.ktc.matgpt.image.ImageService;
-import com.ktc.matgpt.like.likeReview.LikeReviewService;
 import com.ktc.matgpt.review.dto.ReviewRequest;
 import com.ktc.matgpt.review.dto.ReviewResponse;
 import com.ktc.matgpt.review.entity.Review;
@@ -30,7 +29,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.net.URL;
 import java.time.Duration;
@@ -206,13 +204,8 @@ public class ReviewService {
         List<ReviewResponse.FindPageByUserIdDTO.FindByUserIdDTO> reviewDTOs = new ArrayList<>();
 
         for (Review review : reviews) {
-            List<String> imageUrls = imageService.getImageUrlsByReviewId(review.getId());
-            if (imageUrls.isEmpty()) {
-                log.info("reviewId-" + review.getId() + ": 리뷰에 등록된 이미지가 없습니다.");
-            }
-
             String relativeTime = getRelativeTime(review.getCreatedAt());
-            reviewDTOs.add(new ReviewResponse.FindPageByUserIdDTO.FindByUserIdDTO(review, relativeTime, imageUrls));
+            reviewDTOs.add(new ReviewResponse.FindPageByUserIdDTO.FindByUserIdDTO(review, relativeTime));
         }
         return new ReviewResponse.FindPageByUserIdDTO(reviewDTOs, reviews);
     }
@@ -244,7 +237,7 @@ public class ReviewService {
 
         return ReviewResponse.FindByReviewIdDTO.ReviewerDTO.builder()
                         .userName(user.getName())
-                        .profileImage("default profileImage")
+                        .profileImage(user.getProfileImageUrl())
                         .email(user.getEmail())
                         .build();
     }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewResponse.java
@@ -123,10 +123,10 @@ public class ReviewResponse {
         private double rating;
         private String content;
         private LocalDateTime createdAt;
-
         private List<String> imageUrls;
         private boolean isUpdated = false;
         private String relativeTime;
+        private int numOfLikes;
 
 
         public FindAllByStoreIdDTO(Review review, String relativeTime, List<String> imageUrls) {
@@ -136,6 +136,7 @@ public class ReviewResponse {
             this.rating = review.getRating();
             this.createdAt = review.getCreatedAt();
             this.relativeTime = relativeTime;
+            this.numOfLikes = review.getRecommendCount();
 
             if (review.getCreatedAt() != review.getUpdatedAt()) this.isUpdated = true;
         }
@@ -158,27 +159,27 @@ public class ReviewResponse {
         @Getter
         @ToString
         public static class FindByUserIdDTO {
-            private Long reviewId;
+            private Long id;
             private double rating;
             private String content;
             private LocalDateTime createdAt;
             private String storeImage;
             private String storeName;
-            private List<String> imageUrls;
             private String relativeTime;
             private boolean isUpdated = false;
+            private int numOfLikes;
 
 
-            public FindByUserIdDTO(Review review, String relativeTime, List<String> imageUrls) {
-                this.reviewId = review.getId();
+            public FindByUserIdDTO(Review review, String relativeTime) {
+                this.id = review.getId();
                 this.rating = review.getRating();
                 this.content = review.getContent();
                 this.createdAt = review.getCreatedAt();
                 this.storeImage = review.getStore().getStoreImageUrl();
                 this.storeName = review.getStore().getName();
-                this.imageUrls = imageUrls;
                 this.relativeTime = relativeTime;
                 if (review.getCreatedAt() != review.getUpdatedAt()) this.isUpdated = true;
+                this.numOfLikes = review.getRecommendCount();
             }
         }
     }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/mypage/MyPageController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/mypage/MyPageController.java
@@ -39,10 +39,10 @@ public class MyPageController {
 
     // 마이페이지 좋아요한 리뷰 조회
     @GetMapping("/liked-reviews")
-    public ResponseEntity<?> findLikedReviewsByUserId(@AuthenticationPrincipal UserPrincipal userPrincipal) {
-        List<LikeReviewResponseDTO.FindLikeReviewDTO> responseDTOs
-                = likeReviewService.findReviewsByUserEmail(userPrincipal.getEmail());
-        ApiUtils.ApiResult<?> apiResult = ApiUtils.success(responseDTOs);
-        return ResponseEntity.ok(apiResult);
+    public ResponseEntity<?> findLikedReviewsByUserId(@RequestParam(defaultValue = "1") int pageNum,
+                                                      @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        LikeReviewResponseDTO.FindLikeReviewsDTO responseDTO
+                = likeReviewService.findReviewsByUserId(userPrincipal.getId(), pageNum);
+        return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/mypage/MyPageController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/mypage/MyPageController.java
@@ -14,8 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 
 @RequestMapping(value = "/mypage", produces = {"application/json; charset=UTF-8"})
 @RequiredArgsConstructor


### PR DESCRIPTION
## 변경 요약
- 좋아요한 리뷰 조회 페이지네이션 구현
- 응답 DTO 수정
- 리뷰 조회 정렬기준 추천순으로 변경

## 변경 내용
- 리뷰 조회 응답 DTO를 api 문서에 맞춰 수정했습니다.
- 좋아요한 리뷰 조회 응답 DTO를 api에 맞춰 수정했습니다
- 리뷰 작성 api의 RequestPart(image)의 required=false로 변경했습니다
- 리뷰 목록 조회 시 정렬 기준 별점순(임시)이었던 것을 추천순(리뷰 좋아요수)으로 변경했습니다.
- 좋아요한 리뷰 목록 조회 페이지네이션을 구현했습니다.
   - 최신순, offset 기반 페이지네이션으로 구현했습니다.

## 추가 정보
- 좋아요한 리뷰 목록은 최신순으로, 최근 좋아요를 누른 순서대로 정렬되도록 했습니다.
- 정렬 기준과 DTO를 수정함에 따라 ReviewRestControllerTest의 응답 검증도 수정이 필요합니다.