### PR TITLE
페이지네이션 리팩토링 & 코인 기능 구현

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "matgpt/src/main/resources/secret"]
-	path = matgpt/src/main/resources/secret
-	url = https://github.com/nimunsang/secret.git
-    branch = main

--- a/matgpt/src/main/java/com/ktc/matgpt/chatgpt/controller/GptRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/chatgpt/controller/GptRestController.java
@@ -26,7 +26,7 @@ public class GptRestController {
 
     private final GptService gptService;
 
-    @GetMapping("/store/{storeId}/review")
+    @GetMapping("/stores/{storeId}/review")
     public ResponseEntity<?> getReviewSummarys(@PathVariable Long storeId) {
         GptResponseDto<Map<String, String>> gptResponseDto = gptService.findReviewSummaryByStoreId(storeId);
         ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(gptResponseDto);
@@ -41,7 +41,7 @@ public class GptRestController {
     }
 
     // 테스트 전용 API 입니다. 실제로 이 API는 사용되지 않습니다.
-    @PostMapping("/store/{storeId}/review")
+    @PostMapping("/stores/{storeId}/review")
     public ResponseEntity<?> generateReviewSummary(@PathVariable Long storeId) {
         List<GptResponse> gptResponses = gptService.generateReviewSummarys(storeId);
         gptResponses.forEach(gptResponse -> {

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/controller/CoinController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/controller/CoinController.java
@@ -1,0 +1,64 @@
+package com.ktc.matgpt.coin.controller;
+
+import com.ktc.matgpt.coin.dto.CoinRequest;
+import com.ktc.matgpt.coin.dto.CoinResponse;
+import com.ktc.matgpt.coin.service.CoinService;
+import com.ktc.matgpt.security.UserPrincipal;
+import com.ktc.matgpt.utils.ApiUtils;
+import com.ktc.matgpt.utils.PageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/coin")
+@RestController
+public class CoinController {
+
+    private final CoinService coinService;
+
+    @GetMapping("")
+    public ResponseEntity<?> getCoinBalance(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        CoinResponse.BalanceDto balanceDto = coinService.getCoinBalance(userPrincipal.getId());
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(balanceDto);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @PostMapping("/use")
+    public ResponseEntity<?> useCoin(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                     @RequestBody CoinRequest.UseCoinDto useCoinDto) {
+
+        CoinResponse.BalanceDto balanceDto = coinService.useCoin(userPrincipal.getId(), useCoinDto);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(balanceDto);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @PostMapping("/earn")
+    public ResponseEntity<?> earnCoin(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                      @RequestBody CoinRequest.EarnCoinDto earnCoinDto) {
+
+        CoinResponse.BalanceDto balanceDto = coinService.earnCoin(userPrincipal.getId(), earnCoinDto);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(balanceDto);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @GetMapping("/history/usage")
+    public ResponseEntity<?> getCoinUsageHistory(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                 @RequestParam(required = false) Long cursor) {
+
+        PageResponse<?, CoinResponse.UsageHistoryDto> usageHistoriesDto = coinService.getCoinUsageHistory(userPrincipal.getId(), cursor);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(usageHistoriesDto);
+        return ResponseEntity.ok(apiResult);
+    }
+
+    @GetMapping("/history/earning")
+    public ResponseEntity<?> getCoinEarningHistory(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                                   @RequestParam(required = false) Long cursor) {
+
+        PageResponse<?, CoinResponse.EarningHistoryDto> earningHistoriesDto = coinService.getCoinEarningHistory(userPrincipal.getId(), cursor);
+        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(earningHistoriesDto);
+        return ResponseEntity.ok(apiResult);
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/dto/CoinRequest.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/dto/CoinRequest.java
@@ -1,0 +1,41 @@
+package com.ktc.matgpt.coin.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class CoinRequest {
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class UseCoinDto {
+        private int amount;
+
+        public UseCoinDto(int amount) {
+            validateAmount(amount);
+            this.amount = amount;
+        }
+    }
+
+    @ToString
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class EarnCoinDto {
+        private int amount;
+
+        public EarnCoinDto(int amount) {
+            validateAmount(amount);
+            this.amount = amount;
+        }
+    }
+
+    public static void validateAmount(int amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("amount는 음수가 될 수 없습니다.");
+        }
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/dto/CoinResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/dto/CoinResponse.java
@@ -1,0 +1,50 @@
+package com.ktc.matgpt.coin.dto;
+
+
+import com.ktc.matgpt.coin.entity.CoinEarningHistory;
+import com.ktc.matgpt.coin.entity.CoinUsageHistory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class CoinResponse {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BalanceDto {
+        private Long userId;
+        private int balance;
+    }
+
+
+    @Getter
+    @NoArgsConstructor
+    public static class UsageHistoryDto {
+        private int amount;
+        private int balance;
+        private LocalDateTime usedAt;
+
+        public UsageHistoryDto(CoinUsageHistory coinUsageHistory) {
+            this.amount = coinUsageHistory.getAmount() * -1;
+            this.balance = coinUsageHistory.getBalance();
+            this.usedAt = coinUsageHistory.getUsedAt();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class EarningHistoryDto {
+        private int amount;
+        private int balance;
+        private LocalDateTime earnedAt;
+
+        public EarningHistoryDto(CoinEarningHistory coinEarningHistory) {
+            this.amount = coinEarningHistory.getAmount();
+            this.balance = coinEarningHistory.getBalance();
+            this.earnedAt = coinEarningHistory.getEarnedAt();
+        }
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/entity/Coin.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/entity/Coin.java
@@ -1,0 +1,44 @@
+package com.ktc.matgpt.coin.entity;
+
+import com.ktc.matgpt.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Table(name = "coin_tb")
+@Entity
+public class Coin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private int balance;
+
+    public Coin(User user) {
+        this.user = user;
+        this.balance = 0;
+    }
+
+    public static Coin create(User user) {
+        return new Coin(user);
+    }
+
+    public void use(int amount) {
+        this.balance -= amount;
+    }
+
+    public void earn(int amount) {
+        this.balance += amount;
+    }
+
+    public void setBalance(int balance) {
+        this.balance = balance;
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/entity/CoinEarningHistory.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/entity/CoinEarningHistory.java
@@ -1,0 +1,38 @@
+package com.ktc.matgpt.coin.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@Table(name = "coin_earning_history_tb")
+@Entity
+public class CoinEarningHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Coin coin;
+
+    private int balance;
+
+    private int amount;
+
+    private LocalDateTime earnedAt;
+
+    public CoinEarningHistory(Coin coin, int amount) {
+        this.coin = coin;
+        this.balance = coin.getBalance();
+        this.amount = amount;
+        this.earnedAt = LocalDateTime.now();
+    }
+
+    public static CoinEarningHistory create(Coin coin, int amount) {
+        return new CoinEarningHistory(coin, amount);
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/entity/CoinUsageHistory.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/entity/CoinUsageHistory.java
@@ -1,0 +1,38 @@
+package com.ktc.matgpt.coin.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+@Table(name = "coin_usage_history_tb")
+@Entity
+public class CoinUsageHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Coin coin;
+
+    private int balance;
+
+    private int amount;
+
+    private LocalDateTime usedAt;
+
+    public CoinUsageHistory(Coin coin, int amount) {
+        this.coin = coin;
+        this.balance = coin.getBalance();
+        this.amount = amount;
+        this.usedAt = LocalDateTime.now();
+    }
+
+    public static CoinUsageHistory create(Coin coin, int amount) {
+        return new CoinUsageHistory(coin, amount);
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/repository/CoinEarningHistoryRepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/repository/CoinEarningHistoryRepository.java
@@ -1,0 +1,18 @@
+package com.ktc.matgpt.coin.repository;
+
+import com.ktc.matgpt.coin.entity.CoinEarningHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CoinEarningHistoryRepository extends JpaRepository<CoinEarningHistory, Long> {
+    @Query("SELECT ceh FROM CoinEarningHistory ceh JOIN FETCH ceh.coin c WHERE c.id = :coinId ORDER BY ceh.id DESC")
+    Page<CoinEarningHistory> findAllByCoinIdOrderByHistoryIdDesc(@Param("coinId") Long coinId, Pageable pageable);
+
+    @Query("SELECT ceh FROM CoinEarningHistory ceh JOIN FETCH ceh.coin c WHERE c.id = :coinId AND ceh.id < :cursor ORDER BY ceh.id DESC")
+    Page<CoinEarningHistory> findAllByCoinIdLessThanCursor(@Param("coinId") Long coinId, @Param("cursor") Long cursor, Pageable pageable);
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/repository/CoinRepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/repository/CoinRepository.java
@@ -1,0 +1,10 @@
+package com.ktc.matgpt.coin.repository;
+
+import com.ktc.matgpt.coin.entity.Coin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CoinRepository extends JpaRepository<Coin, Long> {
+    Optional<Coin> findByUserId(Long userId);
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/repository/CoinUsageHistoryRepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/repository/CoinUsageHistoryRepository.java
@@ -1,0 +1,18 @@
+package com.ktc.matgpt.coin.repository;
+
+import com.ktc.matgpt.coin.entity.CoinUsageHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CoinUsageHistoryRepository extends JpaRepository<CoinUsageHistory, Long> {
+    @Query("SELECT cuh FROM CoinUsageHistory cuh JOIN FETCH cuh.coin c WHERE c.id = :coinId ORDER BY cuh.id DESC")
+    Page<CoinUsageHistory> findAllByCoinIdOrderByHistoryIdDesc(@Param("coinId") Long coinId, Pageable pageable);
+
+    @Query("SELECT cuh FROM CoinUsageHistory cuh JOIN FETCH cuh.coin c WHERE c.id = :coinId AND cuh.id < :cursor ORDER BY cuh.id DESC")
+    Page<CoinUsageHistory> findAllByCoinIdLessThanCursor(@Param("coinId") Long coinId, @Param("cursor") Long cursor, Pageable pageable);
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/coin/service/CoinService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/coin/service/CoinService.java
@@ -1,0 +1,125 @@
+package com.ktc.matgpt.coin.service;
+
+import com.ktc.matgpt.coin.dto.CoinRequest;
+import com.ktc.matgpt.coin.dto.CoinResponse;
+import com.ktc.matgpt.coin.entity.Coin;
+import com.ktc.matgpt.coin.entity.CoinEarningHistory;
+import com.ktc.matgpt.coin.entity.CoinUsageHistory;
+import com.ktc.matgpt.coin.repository.CoinEarningHistoryRepository;
+import com.ktc.matgpt.coin.repository.CoinRepository;
+import com.ktc.matgpt.coin.repository.CoinUsageHistoryRepository;
+import com.ktc.matgpt.user.entity.User;
+import com.ktc.matgpt.utils.PageResponse;
+import com.ktc.matgpt.utils.Paging;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Service
+public class CoinService {
+
+    private final CoinRepository coinRepository;
+    private final CoinUsageHistoryRepository coinUsageHistoryRepository;
+    private final CoinEarningHistoryRepository coinEarningHistoryRepository;
+    private static final int PAGE_SIZE = 10;
+
+    @Transactional(readOnly = true)
+    public CoinResponse.BalanceDto getCoinBalance(Long userId) {
+        Coin coin = getCoinByUserId(userId);
+        return new CoinResponse.BalanceDto(userId, coin.getBalance());
+    }
+
+    @Transactional
+    public CoinResponse.BalanceDto useCoin(Long userId, CoinRequest.UseCoinDto useCoinDto) {
+        Coin coin = getCoinByUserId(userId);
+        int balance = coin.getBalance();
+        int amount = useCoinDto.getAmount();
+
+        if (balance < amount) {
+            throw new IllegalArgumentException("잔액보다 큰 금액을 사용할 수 없습니다.");
+        }
+
+        coin.use(amount);
+        CoinUsageHistory coinUsageHistory = CoinUsageHistory.create(coin, amount);
+        coinUsageHistoryRepository.save(coinUsageHistory);
+
+        return new CoinResponse.BalanceDto(userId, coin.getBalance());
+    }
+
+    @Transactional
+    public CoinResponse.BalanceDto earnCoin(Long userId, CoinRequest.EarnCoinDto earnCoinDto) {
+        Coin coin = getCoinByUserId(userId);
+        int amount = earnCoinDto.getAmount();
+
+        coin.earn(amount);
+        CoinEarningHistory coinEarningHistory = CoinEarningHistory.create(coin, amount);
+        coinEarningHistoryRepository.save(coinEarningHistory);
+
+        return new CoinResponse.BalanceDto(userId, coin.getBalance());
+    }
+
+    @Transactional
+    public void createCoin(User user) {
+        Coin coin = Coin.create(user);
+        coinRepository.save(coin);
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<?, CoinResponse.EarningHistoryDto> getCoinEarningHistory(Long userId, Long cursor) {
+        Pageable pageable = PageRequest.ofSize(PAGE_SIZE);
+        Coin coin = getCoinByUserId(userId);
+        Page<CoinEarningHistory> coinEarningHistories;
+
+        if (cursor == null) {
+            coinEarningHistories = coinEarningHistoryRepository.findAllByCoinIdOrderByHistoryIdDesc(coin.getId(), pageable);
+        } else {
+            coinEarningHistories = coinEarningHistoryRepository.findAllByCoinIdLessThanCursor(coin.getId(), cursor, pageable);
+        }
+
+        if (coinEarningHistories.isEmpty()) {
+            return new PageResponse<>(new Paging<>(false, 0, null, null), null);
+        }
+
+        int size = coinEarningHistories.getNumberOfElements();
+        Long nextCursor = coinEarningHistories.getContent().get(size - 1).getId();
+        Paging<Long> paging = new Paging<>(coinEarningHistories.hasNext(), size, nextCursor, nextCursor);
+        return new PageResponse<>(paging, coinEarningHistories.stream()
+                .map(CoinResponse.EarningHistoryDto::new)
+                .toList());
+    }
+
+    @Transactional(readOnly = true)
+    public PageResponse<?, CoinResponse.UsageHistoryDto> getCoinUsageHistory(Long userId, Long cursor) {
+        Pageable pageable = PageRequest.ofSize(PAGE_SIZE);
+        Coin coin = getCoinByUserId(userId);
+        Page<CoinUsageHistory> coinUsageHistories;
+
+        if (cursor == null) {
+            coinUsageHistories = coinUsageHistoryRepository.findAllByCoinIdOrderByHistoryIdDesc(coin.getId(), pageable);
+        } else {
+            coinUsageHistories = coinUsageHistoryRepository.findAllByCoinIdLessThanCursor(coin.getId(), cursor, pageable);
+        }
+
+        if (coinUsageHistories.isEmpty()) {
+            return new PageResponse<>(new Paging<>(false, 0, null, null), null);
+        }
+
+        int size = coinUsageHistories.getNumberOfElements();
+        Long nextCursor = coinUsageHistories.getContent().get(size - 1).getId();
+        Paging<Long> paging = new Paging<>(coinUsageHistories.hasNext(), size, nextCursor, nextCursor);
+        return new PageResponse<>(paging, coinUsageHistories.stream()
+                .map(CoinResponse.UsageHistoryDto::new)
+                .toList());
+    }
+
+    private Coin getCoinByUserId(Long userId) {
+        return coinRepository.findByUserId(userId).orElseThrow(
+                () -> new NoSuchElementException(String.format("userId-%s : 존재하지 않는 유저id입니다.", userId)));
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewJPARepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -38,4 +39,10 @@ public interface ReviewJPARepository extends JpaRepository<Review, Long> {
             "WHERE r.userId = :userId AND (r.recommendCount < :cursorLikes OR (r.recommendCount= :cursorLikes AND r.id < :cursorId)) " +
             "ORDER BY r.recommendCount DESC, r.id DESC")
     Page<Review> findAllByUserIdAndOrderByLikesAndIdDesc(Long userId, Long cursorId, int cursorLikes, Pageable page);
+
+    // 모든 리뷰 조회 - 최신순, 커서 기반
+    @Query("SELECT r FROM Review r " +
+            "WHERE r.createdAt < :cursor OR (r.createdAt = :cursor AND r.id < :cursorId)" +
+            "ORDER BY r.createdAt DESC, r.id DESC")
+    List<Review> findAllLessThanCursorOrderByCreatedAtDesc(Long cursorId, LocalDateTime cursor, Pageable page);
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
@@ -1,9 +1,7 @@
 package com.ktc.matgpt.review;
 
-import com.ktc.matgpt.aws.FileValidator;
 import com.ktc.matgpt.exception.CustomException;
 import com.ktc.matgpt.exception.ErrorCode;
-import com.ktc.matgpt.image.ImageService;
 import com.ktc.matgpt.review.dto.ReviewRequest;
 import com.ktc.matgpt.review.dto.ReviewResponse;
 import com.ktc.matgpt.review.entity.Review;
@@ -15,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -71,7 +68,8 @@ public class ReviewRestController {
 
     // 리뷰 수정
     @PutMapping("/{reviewId}")
-    public ResponseEntity<?> update(@PathVariable Long reviewId,
+    public ResponseEntity<?> update(@PathVariable Long storeId,
+                                    @PathVariable Long reviewId,
                                     @RequestBody @Valid ReviewRequest.UpdateDTO requestDTO,
                                     @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
@@ -81,7 +79,8 @@ public class ReviewRestController {
 
     // 개별 리뷰 상세조회
     @GetMapping("/{reviewId}")
-    public ResponseEntity<?> findById(@PathVariable Long reviewId) {
+    public ResponseEntity<?> findById(@PathVariable Long storeId,
+                                      @PathVariable Long reviewId) {
         ReviewResponse.FindByReviewIdDTO responseDTO = reviewService.findDetailByReviewId(reviewId);
         return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }
@@ -89,7 +88,8 @@ public class ReviewRestController {
     // TODO: s3 삭제 구현
     // 리뷰 삭제
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<?> delete(@PathVariable Long reviewId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
+    public ResponseEntity<?> delete(@PathVariable Long storeId,
+                                    @PathVariable Long reviewId, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         reviewService.delete(reviewId, userPrincipal.getId());
         return ResponseEntity.ok(ApiUtils.success("리뷰가 삭제되었습니다."));
     }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewRequest.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewRequest.java
@@ -20,7 +20,7 @@ public class ReviewRequest {
         private int imageCount; //TODO: enum PriceRange 타입 변환 메서드 만들어야할 것
 
 
-        public SimpleCreateDTO(String content, double rating, int peopleCount, int totalPrice, int imageCount) {
+        public SimpleCreateDTO(String content, int rating, int peopleCount, int totalPrice, int imageCount) {
             this.content = content;
             this.rating = rating;
             this.peopleCount = peopleCount;

--- a/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewResponse.java
@@ -232,6 +232,29 @@ public class ReviewResponse {
         }
     }
 
+    @ToString
+    @Getter
+    public static class RecentReviewDTO {
+        private Long id;
+        private double rating;
+        private String content;
+        private LocalDateTime createdAt;
+        private String storeImage;
+        private String storeName;
+        private String relativeTime;
+        private int numOfLikes;
+        private int peopleCount;
 
-
+        public RecentReviewDTO(Review review, String relativeTime) {
+            this.id = review.getId();
+            this.rating = review.getRating();
+            this.content = review.getContent();
+            this.createdAt = review.getCreatedAt();
+            this.storeImage = review.getStore().getStoreImageUrl();
+            this.storeName = review.getStore().getName();
+            this.relativeTime = relativeTime;
+            this.numOfLikes = review.getRecommendCount();
+            this.peopleCount = review.getPeopleCount();
+        }
+    }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/security/oauth2/MatgptOAuth2UserService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/security/oauth2/MatgptOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.ktc.matgpt.security.oauth2;
 
 
+import com.ktc.matgpt.coin.service.CoinService;
 import com.ktc.matgpt.exception.CustomException;
 import com.ktc.matgpt.exception.ErrorCode;
 import com.ktc.matgpt.security.UserPrincipal;
@@ -27,6 +28,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class MatgptOAuth2UserService extends DefaultOAuth2UserService {
 
+    private final CoinService coinService;
     private final UserRepository userRepository;
     // 유저 불러오기
     @Override
@@ -60,6 +62,7 @@ public class MatgptOAuth2UserService extends DefaultOAuth2UserService {
         } else {
             //유저가 존재하지 않는 경우 회원가입 진행
             user = registerUser(oAuth2UserRequest, oauth2UserInfo);
+            coinService.createCoin(user);
         }
         return UserPrincipal.create(user, oauth2UserInfo);
     }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreJPARepository.java
@@ -1,5 +1,6 @@
 package com.ktc.matgpt.store;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,17 +11,17 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface StoreJPARepository extends JpaRepository<Store,Long> {
+public interface StoreJPARepository extends JpaRepository<Store, Long> {
 
     @Query(value = "SELECT s FROM Store s JOIN FETCH s.subCategory sc JOIN FETCH sc.category c WHERE s.id = :id")
     Optional<Store> findById(@Param("id")Long id);
 
-    //거리안의 음식점 marker 가져오기
+    // 거리안의 음식점 marker 가져오기
     @Query(value ="SELECT * FROM store_tb WHERE latitude < :maxLat AND latitude > :minLat AND longitude < :maxLon AND longitude > :minLon", nativeQuery = true)
     List<Store> findAllWithinLatLonBoundaries(@Param("maxLat")double maxLat, @Param("maxLon")double maxLon, @Param("minLat")double minLat, @Param("minLon")double minLon);
 
     // mysql에서는 st_distance_sphere 함수를 사용가능하지만, 배포환경인 mariadb와 h2에서는 사용 불가하므로, 공식을 통해 거리 가져오기
-    //사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기
+    // 사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기 - 커서 기반
     @Query(value = "WITH DistanceCTE AS (" +
             "SELECT s.*, " +
             "6371 * ACOS(" +
@@ -34,42 +35,17 @@ public interface StoreJPARepository extends JpaRepository<Store,Long> {
             nativeQuery = true)
     List<Store> findAllByNearestAndDistanceLessThanCursor(@Param("latitude")double latitude, @Param("longitude")double longitude, @Param("cursor")Double cursor, @Param("lastid")Long lastId, Pageable pageable);
 
-    //사용자의 위치와 음식점 거리가 가까운 순으로 음식점 불러오기
-    @Query(value = "WITH DistanceCTE AS (" +
-            "SELECT s.*, " +
-            "6371 * ACOS(" +
-            "COS(RADIANS(:latitude)) * COS(RADIANS(latitude)) * " +
-            "COS(RADIANS(longitude) - RADIANS(:longitude)) + " +
-            "SIN(RADIANS(:latitude)) * SIN(RADIANS(latitude))" +
-            ") AS distance FROM store_tb s)" +
-            "SELECT * FROM DistanceCTE " +
-            "ORDER BY distance ASC, id DESC",
-            nativeQuery = true)
-    List<Store> findAllByNearest(@Param("latitude")double latitude, @Param("longitude")double longitude, Pageable pageable);
-
-    // 별점 높은 순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.ratingAvg DESC")
-    List<Store> findAllBySearchOrderByRatingDesc(@Param("search")String search, Pageable pageable);
-
-    // 별점 높은 순으로 가게 불러오기 with cursor id
+    // 별점 높은 순으로 가게 불러오기 - 커서 기반
     @Query("SELECT s FROM Store s " +
             "WHERE s.name LIKE %:search% AND (s.ratingAvg < :cursor OR (s.ratingAvg = :cursor AND s.id < :lastid))" +
             "ORDER by s.ratingAvg DESC, s.id DESC")
     List<Store> findAllBySearchAndRatingLessThanCursor(@Param("search")String search, @Param("cursor")Long cursor, @Param("lastid")Long lastId, Pageable pageable);
 
-    // id 내림차순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER by s.id DESC")
-    List<Store> findAllBySearchOrderByIdDesc(@Param("search")String search, Pageable pageable);
-
-    // id 내림차순으로 가게 불러오기 with cursor id
+    // id 내림차순으로 가게 불러오기 - 커서 기반
     @Query("SELECT s FROM Store s WHERE s.id < :cursor AND s.name LIKE %:search% ORDER by s.id DESC")
     List<Store> findAllBySearchAndIdLessThanCursor(@Param("search")String search, @Param("cursor")Long cursor, Pageable pageable);
 
-    // 리뷰 많은 순으로 가게 불러오기
-    @Query("SELECT s FROM Store s WHERE s.name LIKE %:search% ORDER BY s.numsOfReview DESC, s.id DESC")
-    List<Store> findAllBySearchOrderByNumsOfReviewDesc(@Param("search")String search, Pageable pageable);
-
-    // 리뷰 많은 순으로 가게 불러오기 with cursor id
+    // 리뷰 많은 순으로 가게 불러오기 - 커서 기반
     @Query("SELECT s " +
             "FROM Store s " +
             "WHERE s.name LIKE %:search% AND (s.numsOfReview < :cursor OR (s.numsOfReview = :cursor AND s.id < :lastId))" +

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreRestController.java
@@ -1,6 +1,8 @@
 package com.ktc.matgpt.store;
 
+import com.ktc.matgpt.review.dto.ReviewResponse;
 import com.ktc.matgpt.security.UserPrincipal;
+import com.ktc.matgpt.store.usecase.GetRecentlyReviewedStoresUseCase;
 import com.ktc.matgpt.utils.ApiUtils;
 import com.ktc.matgpt.utils.PageResponse;
 import lombok.RequiredArgsConstructor;
@@ -8,71 +10,72 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/store")
+@RequestMapping("/stores")
 public class StoreRestController {
 
     private final StoreService storeService;
-    private static final int PAGE_DEFAULT_SIZE = 5;
+    private final GetRecentlyReviewedStoresUseCase getRecentlyReviewedStoresUseCase;
 
     @GetMapping("/{storeId}")
     public ResponseEntity<?> findById(@PathVariable Long storeId) {
         StoreResponse.FindByIdStoreDTO responseDTO = storeService.getStoreDtoById(storeId);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTO);
-        return ResponseEntity.ok(apiResult);
+        return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }
 
     //마커 찍는 stores 보내주기
     @GetMapping("/boundary")
-    public ResponseEntity<?> getMarkedStores(@RequestParam(value = "maxlat") double maxLat,
-                                             @RequestParam(value = "maxlon") double maxLon,
-                                             @RequestParam(value = "minlat") double minLat,
-                                             @RequestParam(value = "minlon") double minLon) {
+    public ResponseEntity<?> getMarkedStores(@RequestParam(value = "maxlat", defaultValue = "180") double maxLat,
+                                             @RequestParam(value = "maxlon", defaultValue = "180") double maxLon,
+                                             @RequestParam(value = "minlat", defaultValue = "0") double minLat,
+                                             @RequestParam(value = "minlon", defaultValue = "0") double minLon) {
         List<StoreResponse.MarkerStoresDTO> responseDTOs = storeService.findAllMarkers(maxLat, maxLon, minLat, minLon);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
-        return ResponseEntity.ok(apiResult);
+        return ResponseEntity.ok(ApiUtils.success(responseDTOs));
     }
 
     //사용자 거리와 가까운 순으로 불러오기
     @GetMapping("/nearest")
     public ResponseEntity<?> findNearestStores(@RequestParam(value = "lati") double latitude,
                                                @RequestParam(value = "longi") double longitude,
-                                               @RequestParam(value = "cursor", required = false, defaultValue = "-1.0") Double cursor,
-                                               @RequestParam(value = "lastid", required = false) Long lastId) {
-        PageResponse<Double, StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findAllByDistance(latitude, longitude, cursor, lastId, PAGE_DEFAULT_SIZE);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(responseDTOs);
-        return ResponseEntity.ok(apiResult);
+                                               @RequestParam(required = false) Double cursor,
+                                               @RequestParam(value = "cursorid", required = false) Long cursorId) {
+        PageResponse<Double, StoreResponse.FindAllStoreDTO> responseDTOs = storeService.findAllByDistance(latitude, longitude, cursor, cursorId);
+        return ResponseEntity.ok(ApiUtils.success(responseDTOs));
     }
 
     //음식점 검색
     @GetMapping("/search")
     public ResponseEntity<?> search(@RequestParam(value = "sort", defaultValue = "id") String sort,
-                                    @RequestParam(value = "cursor", required = false, defaultValue = "-1") Long cursor,
-                                    @RequestParam(value = "lastid", required = false) Long lastId,
-                                    @RequestParam(value= "q") String searchQuery ) {
-        PageResponse<?, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findBySearch(searchQuery, cursor, lastId, PAGE_DEFAULT_SIZE, sort);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
-        return ResponseEntity.ok(apiResult);
+                                    @RequestParam(value= "q", required = false) String searchQuery,
+                                    @RequestParam(required = false) Long cursor,
+                                    @RequestParam(value = "cursorid", required = false) Long cursorId) {
+        PageResponse<?, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findBySearch(searchQuery, cursor, cursorId, sort);
+        return ResponseEntity.ok(ApiUtils.success(pageResponse));
     }
 
     //인기 많은 음식점 - 리뷰 갯수 순
     @GetMapping("/popular")
-    public ResponseEntity<?> findByHighestReviewCount(@RequestParam(value = "cursor", required = false, defaultValue = "-1") Integer cursor,
-                                                      @RequestParam(value = "lastid", required = false) Long lastId) {
-        PageResponse<Integer, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findByHighestReviewCount(cursor, lastId, PAGE_DEFAULT_SIZE);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
-        return ResponseEntity.ok(apiResult);
+    public ResponseEntity<?> findByHighestReviewCount(@RequestParam(required = false) Integer cursor,
+                                                      @RequestParam(value = "cursorid", required = false) Long cursorId) {
+        PageResponse<Integer, StoreResponse.FindAllStoreDTO> pageResponse = storeService.findByHighestReviewCount(cursor, cursorId);
+        return ResponseEntity.ok(ApiUtils.success(pageResponse));
     }
 
-    // 비슷한 사용자들이 좋아하는 음식점
+    // 비슷한 사용자들이 좋아하는 음식점 5개
     @GetMapping("/similar")
-    public ResponseEntity<?> getMostLikedStoresBySimilarUsers(@AuthenticationPrincipal UserPrincipal userPrincipal,
-                                                              @RequestParam(value = "cursor", required = false, defaultValue = "-1") Long cursor) {
-        PageResponse<Long, StoreResponse.FindAllStoreDTO> pageResponse = storeService.getMostLikedStoresBySimilarUsers(userPrincipal.getEmail(), cursor, PAGE_DEFAULT_SIZE);
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(pageResponse);
-        return ResponseEntity.ok(apiResult);
+    public ResponseEntity<?> getMostLikedStoresBySimilarUsersTop5(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        List<StoreResponse.FindAllStoreDTO> pageResponse = storeService.getMostLikedStoresBySimilarUsersTop5(userPrincipal.getEmail());
+        return ResponseEntity.ok(ApiUtils.success(pageResponse));
+    }
+
+    @GetMapping("/recent-reviews")
+    public ResponseEntity<?> getRecentlyReviewedStores(@RequestParam(required = false) LocalDateTime cursor,
+                                                       @RequestParam(value = "cursorid", required = false) Long cursorId) {
+        PageResponse<LocalDateTime, ReviewResponse.RecentReviewDTO> recentlyReviewedStores = getRecentlyReviewedStoresUseCase.execute(cursorId, cursor);
+        return ResponseEntity.ok(ApiUtils.success(recentlyReviewedStores));
     }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/StoreService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/StoreService.java
@@ -5,12 +5,11 @@ import com.ktc.matgpt.exception.ErrorCode;
 import com.ktc.matgpt.like.likeStore.LikeStoreService;
 import com.ktc.matgpt.user.entity.User;
 import com.ktc.matgpt.user.service.UserService;
-import com.ktc.matgpt.utils.CursorRequest;
 import com.ktc.matgpt.utils.PageResponse;
+import com.ktc.matgpt.utils.Paging;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,11 +26,13 @@ public class StoreService {
     private final LikeStoreService likeStoreService;
     private final StoreJPARepository storeJPARepository;
     private final EntityManager entityManager;
+    private static final int PAGE_SIZE_PLUS_ONE = 5 + 1;
 
     // 마커 표시할 음식점 보기
     @Transactional(readOnly = true)
     public List<StoreResponse.MarkerStoresDTO> findAllMarkers(double maxLat, double maxLon, double minLat, double minLon) {
         validateLatLonBoundary(List.of(maxLat, maxLon, minLat, minLon));
+
         List<Store> stores = storeJPARepository.findAllWithinLatLonBoundaries(maxLat, maxLon, minLat, minLon);
         return stores.stream()
                 .map(StoreResponse.MarkerStoresDTO::new)
@@ -40,25 +41,29 @@ public class StoreService {
 
     // 사용자에게 가까운 순으로 보기 + 커서 기반 페이지네이션
     @Transactional(readOnly = true)
-    public PageResponse<Double, StoreResponse.FindAllStoreDTO> findAllByDistance(double latitude, double longitude, Double cursor, Long lastId, int size) {
+    public PageResponse<Double, StoreResponse.FindAllStoreDTO> findAllByDistance(double latitude, double longitude, Double cursor, Long lastId) {
+        // 가까운 순이므로 거리 최솟값이 cursor
+        cursor = Paging.convertNullCursorToMinValue(cursor);
         validateLatLonBoundary(List.of(latitude, longitude));
-        Pageable pageable = PageRequest.of(0, size);
-        List<Store> stores = getStoreListByDistance(latitude, longitude, cursor, lastId, pageable);
-        return findAllStores(store -> store.calculateDistanceFromLatLon(latitude, longitude), stores, size);
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_PLUS_ONE);
+        List<Store> stores = storeJPARepository.findAllByNearestAndDistanceLessThanCursor(latitude, longitude, cursor, lastId, pageable);
+
+        return extractCursorAndGetPageResponse(store -> store.calculateDistanceFromLatLon(latitude, longitude), stores);
     }
 
-    // 인기 많은 음식점 보기 (리뷰많은순정렬)
+    // 리뷰 많은 순으로 음식점 보기
     @Transactional(readOnly = true)
-    public PageResponse<Integer, StoreResponse.FindAllStoreDTO> findByHighestReviewCount(Integer cursor, Long lastId, int size) {
-        Pageable pageable = PageRequest.of(0, size);
+    public PageResponse<Integer, StoreResponse.FindAllStoreDTO> findByHighestReviewCount(Integer cursor, Long lastId) {
+        cursor = Paging.convertNullCursorToMaxValue(cursor);
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_PLUS_ONE);
         List<Store> stores = getStoreListByReviews("", cursor, lastId, pageable);
-        return findAllStores(Store::getNumsOfReview, stores, size);
+
+        return extractCursorAndGetPageResponse(Store::getNumsOfReview, stores);
     }
 
     //비슷한 사용자들이 좋아하는 음식점 보기
-    //TODO : 예외처리 해주기
     @Transactional(readOnly = true)
-    public PageResponse<Long, StoreResponse.FindAllStoreDTO> getMostLikedStoresBySimilarUsers(String email, Long cursor, int size) {
+    public List<StoreResponse.FindAllStoreDTO> getMostLikedStoresBySimilarUsersTop5(String email) {
         User user = userService.findByEmail(email);
         List<User> similarUserList = userService.findByAgeGroupAndGender(user.getAgeGroup(), user.getGender());
 
@@ -79,28 +84,32 @@ public class StoreService {
 
         //내림차순 정렬
         List<Store> stores = new ArrayList<>(storeHashMap.keySet());
-        Collections.sort(stores,(v1,v2) -> (storeHashMap.get(v2).compareTo(storeHashMap.get(v1))));
+        Collections.sort(stores,(v1, v2) -> (storeHashMap.get(v2).compareTo(storeHashMap.get(v1))));
 
-        return findAllStores(Store::getId, stores, size);
+        return stores.stream()
+                .map(StoreResponse.FindAllStoreDTO::new)
+                .limit(5)
+                .toList();
     }
 
     // 음식점 검색
     @Transactional(readOnly = true)
-    public PageResponse<? extends Comparable<?>, StoreResponse.FindAllStoreDTO> findBySearch(String search, Long cursor, Long lastId, int size, String sort) {
-        Pageable pageable = PageRequest.of(0, size);
+    public PageResponse<? extends Comparable<?>, StoreResponse.FindAllStoreDTO> findBySearch(String search, Long cursor, Long lastId, String sort) {
+        cursor = Paging.convertNullCursorToMaxValue(cursor);
+        Pageable pageable = Pageable.ofSize(PAGE_SIZE_PLUS_ONE);
         List<Store> stores;
         switch (sort) {
             case "id" -> { // 높을수록 우선순위
-                stores = getStoreListById(search, cursor, pageable);
-                return findAllStores(Store::getId, stores, size);
+                stores = storeJPARepository.findAllBySearchAndIdLessThanCursor(search, cursor, pageable);
+                return extractCursorAndGetPageResponse(Store::getId, stores);
             }
             case "rating" -> { // 높을수록 우선순위
-                stores = getStoreListByStar(search, cursor, lastId, pageable);
-                return findAllStores(Store::getRatingAvg, stores, size);
+                stores = storeJPARepository.findAllBySearchAndRatingLessThanCursor(search, cursor, lastId, pageable);
+                return extractCursorAndGetPageResponse(Store::getRatingAvg, stores);
             }
             case "review" -> { // 높을수록 우선순위
                 stores = getStoreListByReviews(search, Math.toIntExact(cursor), lastId, pageable);
-                return findAllStores(Store::getNumsOfReview, stores, size);
+                return extractCursorAndGetPageResponse(Store::getNumsOfReview, stores);
             }
             default -> throw new IllegalArgumentException(String.format("sort : %s 지원하지 않는 정렬 기준입니다.", sort));
         }
@@ -136,20 +145,28 @@ public class StoreService {
         }
     }
 
-    private <T extends Comparable<T>> PageResponse<T, StoreResponse.FindAllStoreDTO> findAllStores(Function<Store, T> cursorExtractor, List<Store> stores, int size) {
+    private <T extends Comparable<T>> PageResponse<T, StoreResponse.FindAllStoreDTO> extractCursorAndGetPageResponse(Function<Store, T> cursorExtractor, List<Store> stores) {
         if (stores.isEmpty()) {
-            return new PageResponse<>(new CursorRequest<>(null, null, size), List.of());
+            return new PageResponse<>(new Paging<>(false, 0, null, null), List.of());
+        }
+
+        int size = stores.size();
+        boolean hasNext = false;
+        if (size == PAGE_SIZE_PLUS_ONE) {
+            stores.remove(size - 1);
+            size -= 1;
+            hasNext = true;
         }
 
         List<StoreResponse.FindAllStoreDTO> findAllStoreDTOS = stores.stream()
                 .map(StoreResponse.FindAllStoreDTO::new)
                 .toList();
 
-        Store lastStore = stores.get(stores.size() - 1);
+        Store lastStore = stores.get(size - 1);
         T nextCursor = cursorExtractor.apply(lastStore);
-        Long nextId = lastStore.getId();
+        Long nextCursorId = lastStore.getId();
 
-        return new PageResponse<>(new CursorRequest<>(nextCursor, nextId, size), findAllStoreDTOS);
+        return new PageResponse<>(new Paging<>(hasNext, size, nextCursor, nextCursorId), findAllStoreDTOS);
     }
 
     private void validateLatLonBoundary(List<Double> latlons) {
@@ -159,28 +176,7 @@ public class StoreService {
             }
         }
     }
-
-    private List<Store> getStoreListById(String search, Long cursor, Pageable pageable) {
-        return cursor == -1
-                ? storeJPARepository.findAllBySearchOrderByIdDesc(search, pageable)
-                : storeJPARepository.findAllBySearchAndIdLessThanCursor(search, cursor, pageable);
-    }
-
-    private List<Store> getStoreListByStar(String search, Long cursor, Long lastId, Pageable pageable) {
-        return cursor == -1
-                ? storeJPARepository.findAllBySearchOrderByRatingDesc(search, pageable)
-                : storeJPARepository.findAllBySearchAndRatingLessThanCursor(search,cursor, lastId, pageable);
-    }
-
     private List<Store> getStoreListByReviews(String search, Integer cursor, Long lastId, Pageable pageable) {
-        return cursor == -1
-            ? storeJPARepository.findAllBySearchOrderByNumsOfReviewDesc(search, pageable)
-            : storeJPARepository.findAllBySearchAndNumsOfReviewLessThanCursor(search, cursor, lastId, pageable);
-    }
-
-    private List<Store> getStoreListByDistance(double latitude, double longitude, Double cursor, Long lastId, Pageable pageable) {
-        return cursor == -1.0
-                ? storeJPARepository.findAllByNearest(latitude, longitude, pageable)
-                : storeJPARepository.findAllByNearestAndDistanceLessThanCursor(latitude, longitude, cursor, lastId, pageable);
+        return storeJPARepository.findAllBySearchAndNumsOfReviewLessThanCursor(search, cursor, lastId, pageable);
     }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/store/usecase/GetRecentlyReviewedStoresUseCase.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/store/usecase/GetRecentlyReviewedStoresUseCase.java
@@ -1,0 +1,24 @@
+package com.ktc.matgpt.store.usecase;
+
+import com.ktc.matgpt.review.ReviewService;
+import com.ktc.matgpt.review.dto.ReviewResponse;
+import com.ktc.matgpt.utils.PageResponse;
+import com.ktc.matgpt.utils.Paging;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@Service
+public class GetRecentlyReviewedStoresUseCase {
+
+    private final ReviewService reviewService;
+
+    public PageResponse<LocalDateTime, ReviewResponse.RecentReviewDTO> execute(Long cursorId, LocalDateTime cursor) {
+        cursorId = Paging.convertNullCursorToMaxValue(cursorId);
+        cursor = Paging.convertNullCursorToMaxValue(cursor);
+        System.out.println(cursor);
+        return reviewService.getRecentlyReviewedStores(cursorId, cursor);
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/utils/CursorRequest.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/utils/CursorRequest.java
@@ -1,7 +1,0 @@
-package com.ktc.matgpt.utils;
-
-public record CursorRequest<T> (
-        T nextCursor,
-        Long lastId,
-        int size
-) {}

--- a/matgpt/src/main/java/com/ktc/matgpt/utils/PageResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/utils/PageResponse.java
@@ -3,6 +3,6 @@ package com.ktc.matgpt.utils;
 import java.util.List;
 
 public record PageResponse<T, U> (
-        CursorRequest<T> cursorRequest,
+        Paging<T> paging,
         List<U> body
 ){}

--- a/matgpt/src/main/java/com/ktc/matgpt/utils/Paging.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/utils/Paging.java
@@ -1,0 +1,27 @@
+package com.ktc.matgpt.utils;
+
+import java.time.LocalDateTime;
+
+public record Paging<T> (
+        boolean hasNext,
+        int size,
+        T nextCursor,
+        Long nextCursorId
+) {
+
+    public static Double convertNullCursorToMinValue(Double cursor) {
+        return cursor != null ? cursor : Double.MIN_VALUE;
+    }
+
+    public static Integer convertNullCursorToMaxValue(Integer cursor) {
+        return cursor != null ? cursor : Integer.MAX_VALUE;
+    }
+
+    public static Long convertNullCursorToMaxValue(Long cursor) {
+        return cursor != null ? cursor : Long.MAX_VALUE;
+    }
+
+    public static LocalDateTime convertNullCursorToMaxValue(LocalDateTime cursor) {
+        return cursor != null ? cursor : LocalDateTime.now().plusYears(1000);
+    }
+}

--- a/matgpt/src/main/resources/custom.sql
+++ b/matgpt/src/main/resources/custom.sql
@@ -121,3 +121,6 @@ INSERT INTO likereview_tb(review_id, user_id)VALUES (7, 1);
 INSERT INTO likereview_tb(review_id, user_id)VALUES (2, 2);
 INSERT INTO likereview_tb(review_id, user_id)VALUES (7, 2);
 INSERT INTO likereview_tb(review_id, user_id)VALUES (7, 2);
+
+INSERT INTO coin_tb(id, user_id, balance) VALUES (1, 1, 0);
+INSERT INTO coin_tb(id, user_id, balance) VALUES (2, 2, 0);

--- a/matgpt/src/test/java/com/ktc/matgpt/coin/CoinControllerTest.java
+++ b/matgpt/src/test/java/com/ktc/matgpt/coin/CoinControllerTest.java
@@ -1,0 +1,180 @@
+package com.ktc.matgpt.coin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ktc.matgpt.coin.dto.CoinRequest;
+import com.ktc.matgpt.coin.entity.Coin;
+import com.ktc.matgpt.coin.repository.CoinRepository;
+import com.ktc.matgpt.security.UserPrincipal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith({ SpringExtension.class, MockitoExtension.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class CoinControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private CoinRepository coinRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DisplayName("코인 잔액 확인 테스트")
+    @Test
+    void getCoinBalance_test() throws Exception {
+
+        // given
+        Long userId = 1L;
+        int lastBalance = 0;
+        UserPrincipal mockUserPrincipal = new UserPrincipal(userId, "nstgic3@gmail.com", false, Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_GUEST")));
+
+        Coin coin = coinRepository.findByUserId(userId).get();
+        coin.setBalance(lastBalance);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                get("/coin")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.data.userId").value(userId));
+        resultActions.andExpect(jsonPath("$.data.balance").value(lastBalance));
+    }
+
+    @DisplayName("코인 획득 테스트")
+    @Transactional
+    @Test
+    void earnCoin_test() throws Exception {
+
+        // given
+        Long userId = 1L;
+        int lastBalance = 1000;
+        int amount = 1000;
+        UserPrincipal mockUserPrincipal = new UserPrincipal(userId, "nstgic3@gmail.com", false, Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_GUEST")));
+
+        Coin coin = coinRepository.findByUserId(userId).get();
+        coin.setBalance(lastBalance);
+
+        CoinRequest.EarnCoinDto earnCoinDto = new CoinRequest.EarnCoinDto(amount);
+        String content = objectMapper.writeValueAsString(earnCoinDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                post("/coin/earn")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUserPrincipal))
+                        .content(content)
+                        .characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print()
+                );
+
+        // then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.data.userId").value(userId));
+        resultActions.andExpect(jsonPath("$.data.balance").value(lastBalance + amount));
+
+    }
+
+    @DisplayName("코인 사용 실패 - 잔액 부족")
+    @Transactional
+    @Test
+    void useCoin_fail_test() throws Exception {
+
+        // given
+        // 0원을 이미 가지고 있었다고 가정
+        Long userId = 1L;
+        int lastBalance = 0;
+        int amount = 1000;
+        UserPrincipal mockUserPrincipal = new UserPrincipal(userId, "nstgic3@gmail.com", false, Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_GUEST")));
+
+        Coin coin = coinRepository.findByUserId(userId).get();
+        coin.setBalance(lastBalance);
+
+        CoinRequest.UseCoinDto useCoinDto = new CoinRequest.UseCoinDto(amount);
+        String content = objectMapper.writeValueAsString(useCoinDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                post("/coin/use")
+                        .with(SecurityMockMvcRequestPostProcessors.user(mockUserPrincipal))
+                        .content(content)
+                        .characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print()
+                );
+
+        // then
+        resultActions.andExpect(status().isBadRequest());
+    }
+
+    @DisplayName("코인 사용 성공 테스트")
+    @Transactional
+    @Test
+    void useCoin_success_test() throws Exception {
+
+        // given
+        // 1000원을 이미 가지고 있었다고 가정
+        Long userId = 1L;
+        int lastBalance = 1000;
+        int amount = 1000;
+        UserPrincipal mockUserPrincipal = new UserPrincipal(userId, "nstgic3@gmail.com", false, Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_GUEST")));
+
+        Coin coin = coinRepository.findByUserId(userId).get();
+        coin.setBalance(lastBalance);
+
+        CoinRequest.UseCoinDto useCoinDto = new CoinRequest.UseCoinDto(amount);
+        String content = objectMapper.writeValueAsString(useCoinDto);
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                post("/coin/use")
+                                .with(SecurityMockMvcRequestPostProcessors.user(mockUserPrincipal))
+                                .content(content)
+                                .characterEncoding("UTF-8")
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .accept(MediaType.APPLICATION_JSON_VALUE))
+                .andDo(print()
+                );
+
+        // then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(jsonPath("$.data.userId").value(userId));
+        resultActions.andExpect(jsonPath("$.data.balance").value(lastBalance - amount));
+    }
+}


### PR DESCRIPTION
## 변경 요약
- api 명세 변경
- 페이지네이션 응답 변경에 의한 페이지네이션 리팩토링
- 코인 기능 구현

## 변경 배경
- Review의 api 명세가 변경됨에 따라, store와 gpt의 api 명세도 변경했습니다. (/store -> /stores)
- 페이지네이션의 hasNext 필드를 추가해야 했습니다. hasNext필드가 존재하지 않는다면, 조회를 한번 더 해야하는 문제가 있었습니다.
- 각 도메인에서 사용하는 페이지네이션의 응답 dto가 통일되지 않았습니다.
- 사용자의 코인 기능을 구현했습니다.

## 변경 사항
- 더이상 사용하지 않는 .gitmodule 삭제
- gptController, storeController의 api 명세 변경 (/store ->  /stores)
- 페이지네이션 api format 통일 (hasNext 필드 추가)
- 페이지네이션에서의 null 처리 방법 변경
- hasNext 필드 추가에 따른 코드 리팩토링
- 최근 리뷰가 올라온 음식점 조회 기능 추가 (+페이지네이션)
- 코인 기능 추가
- 코인 사용 내역 / 코인 충전 내역 확인 가능
- 코인 기능 테스트 코드 추가
- 타입 불일치로 인한 코드 실행 불가 픽스


## 테스트 방법
![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/cb0a0124-ae21-4db9-883d-38410efbd5b3)

- `GET /coin` : 로그인된 사용자의 코인 잔액 확인
- `POST /coin/use` : 사용자의 코인 사용
- `POST /coin/earn` : 사용자의 코인 충전
- `GET /coin/history/usage` : 사용자의 코인 사용 내역 확인
- `GET /coin/history/earning` : 사용자의 코인 충전 내역 확인


![image](https://github.com/Step3-kakao-tech-campus/Team4_BE/assets/64733547/338574e3-a80d-4174-9e8d-ec05252922e7)
- paging 응답 통일

## 추가 정보
Store 관련 기능 변경에 의한 테스트 코드 수정 필요