### PR TITLE
즐겨찾기한 음식점 LikeStore 목록 조회 페이지네이션 추가 및 응답 형식 수정

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreJPARepository.java
@@ -2,6 +2,7 @@ package com.ktc.matgpt.like.likeStore;
 
 import com.ktc.matgpt.store.Store;
 import com.ktc.matgpt.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,10 @@ public interface LikeStoreJPARepository extends JpaRepository<LikeStore, Long> {
 
     @Query( "select h.store from LikeStore h where h.user.id = :userId")
     List<Store> findLikedStoresByUserId(Long userId);
+
+    @Query( "select h from LikeStore h join fetch h.user join fetch h.store " +
+            "where h.user.id = :userId and h.id < :cursorId order by h.id desc")
+    List<LikeStore> findLikedStoresByUserId(Long userId, Long cursorId, Pageable page);
     boolean existsByUserAndStore(User userRef, Store storeRef);
     void deleteByUserAndStore(User user, Store store);
 

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreResponseDTO.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreResponseDTO.java
@@ -1,42 +1,25 @@
 package com.ktc.matgpt.like.likeStore;
 
 import com.ktc.matgpt.store.Store;
-import com.ktc.matgpt.user.entity.User;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class LikeStoreResponseDTO {
-
     @Getter
     @Setter
     public static class FindAllLikeStoresDTO{
 
-        private Long userId;
-        private List<StoreDTO> storeList;
+        private Long storeId;
+        private String storeName;
+        private double ratingAvg;
+        private int numsOfReview;
 
-        public FindAllLikeStoresDTO(User user, List<Store> storeList){
-            this.userId = user.getId();
-            this.storeList = storeList.stream().map(StoreDTO::new).collect(Collectors.toList());
-
-
+        public FindAllLikeStoresDTO(Store store){
+            this.storeId = store.getId();
+            this.storeName = store.getName();
+            this.ratingAvg = store.getAvgRating();
+            this.numsOfReview = store.getNumsOfReview();
         }
 
-        @Getter @Setter
-        public class StoreDTO{
-            private Long storeId;
-            private String storeName;
-            private double ratingAvg;
-            private int numsOfReview;
-
-            public StoreDTO(Store store){
-                this.storeId = store.getId();
-                this.storeName = store.getName();
-                this.ratingAvg = store.getAvgRating();
-                this.numsOfReview = store.getNumsOfReview();
-            }
-        }
     }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreRestController.java
@@ -4,6 +4,7 @@ package com.ktc.matgpt.like.likeStore;
 import com.ktc.matgpt.like.usecase.CreateLikeStoreUseCase;
 import com.ktc.matgpt.security.UserPrincipal;
 import com.ktc.matgpt.utils.ApiUtils;
+import com.ktc.matgpt.utils.PageResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -13,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("")
+@RequestMapping(value = "", produces = {"application/json; charset=UTF-8"})
 public class LikeStoreRestController {
 
     private final LikeStoreService likeStoreService;
@@ -31,10 +32,11 @@ public class LikeStoreRestController {
     }
 
     @GetMapping("/stores/like")
-    public ResponseEntity<?> findAllStores(@AuthenticationPrincipal UserPrincipal userPrincipal){
-        LikeStoreResponseDTO.FindAllLikeStoresDTO heartResponseDTO = likeStoreService.findStoresByUserEmail(userPrincipal.getEmail());
-        ApiUtils.ApiSuccess<?> apiResult = ApiUtils.success(heartResponseDTO);
-        return ResponseEntity.ok(apiResult);
+    public ResponseEntity<?> findAllStores(@AuthenticationPrincipal UserPrincipal userPrincipal,
+                                           @RequestParam(required = false) Long cursorId) {
+        PageResponse<Long, LikeStoreResponseDTO.FindAllLikeStoresDTO> heartResponseDTO
+                                            = likeStoreService.findLikeStoresByUserEmail(userPrincipal.getEmail(), cursorId);
+        return ResponseEntity.ok(ApiUtils.success(heartResponseDTO));
 
     }
 

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeStore/LikeStoreService.java
@@ -1,20 +1,26 @@
 package com.ktc.matgpt.like.likeStore;
 
-
 import com.ktc.matgpt.store.Store;
-import com.ktc.matgpt.store.StoreService;
 import com.ktc.matgpt.user.entity.User;
 import com.ktc.matgpt.user.service.UserService;
+import com.ktc.matgpt.utils.PageResponse;
+import com.ktc.matgpt.utils.Paging;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class LikeStoreService {
+
+    private static final int DEFAULT_PAGE_SIZE = 8;
 
     private final UserService userService;
     private final LikeStoreJPARepository likeStoreJPARepository;
@@ -31,10 +37,22 @@ public class LikeStoreService {
             return true;
         }
     }
-    public LikeStoreResponseDTO.FindAllLikeStoresDTO findStoresByUserEmail(String email) {
-        User user = userService.findByEmail(email);
-        List<Store> storeList=  likeStoreJPARepository.findLikedStoresByUserId(user.getId()).stream().toList();
-        return new LikeStoreResponseDTO.FindAllLikeStoresDTO(user,storeList);
+    public PageResponse<Long, LikeStoreResponseDTO.FindAllLikeStoresDTO> findLikeStoresByUserEmail(String email, Long cursorId) {
+        User userRef = userService.getReferenceByEmail(email);
+        cursorId = Paging.convertNullCursorToMaxValue(cursorId);
+        Pageable page = PageRequest.ofSize(DEFAULT_PAGE_SIZE+1);
+
+        List<LikeStore> likeStoreList = likeStoreJPARepository.findLikedStoresByUserId(userRef.getId(), cursorId, page);
+        if (likeStoreList.isEmpty()) {
+            return new PageResponse<>(new Paging<>(false, 0, null, null), null);
+        }
+
+        Paging paging = getPagingInfo(likeStoreList);
+        likeStoreList = likeStoreList.subList(0, paging.size());
+
+        return new PageResponse<>(paging, likeStoreList.stream().map(likeStore ->
+                        new LikeStoreResponseDTO.FindAllLikeStoresDTO(likeStore.getStore()))
+                .collect(Collectors.toList()));
     }
 
     @Transactional
@@ -53,5 +71,20 @@ public class LikeStoreService {
 
     private boolean isHeartAlreadyExists(User userRef, Store storeRef) {
         return likeStoreJPARepository.existsByUserAndStore(userRef, storeRef);
+    }
+
+    private Paging<Long> getPagingInfo(List<LikeStore> likeStoreList) {
+        boolean hasNext = false;
+        int numsOfReviews = 0;
+
+        if (likeStoreList.size() == DEFAULT_PAGE_SIZE+1) {
+            hasNext = true;
+            numsOfReviews = DEFAULT_PAGE_SIZE;
+        } else {
+            numsOfReviews = likeStoreList.size();
+        }
+
+        Long nextCursorId = likeStoreList.get(numsOfReviews-1).getId();
+        return new Paging<Long>(hasNext, numsOfReviews, nextCursorId, nextCursorId);
     }
 }


### PR DESCRIPTION
## 변경 사항
- LikeStore 목록 조회 시 페이지네이션(커서 기반)을 구현했습니다.
   - LikeStore 레포지토리의 조회 쿼리문을 수정했습니다.
      - Store 목록을 받아오던 것을 LikeStore 목록을 받아오도록 수정했습니다.
      - join fetch를 이용해 이후 사용될 User와 Store를 한 번에 가져오도록 했습니다.
      - LikeStore.id 기준으로 내림차순 정렬해 좋아요가 등록된 최신순으로 목록을 받아옵니다.
   - List 형태로 default size보다 하나 더 조회해 hasNext와 받아온 page size를 계산합니다.
   - 커서 기반 페이지네이션을 위한 cursorId를 RequestParam으로 추가했습니다.
   - cursorId가 null인 경우(최초 요청), Paging을 이용해 해당 타입의 최댓값으로 대체되게 했습니다.
- LikeStore 목록 조회 응답 형식을 수정했습니다.
   - Paging과 PageResponse를 사용해 타 도메인과 응답 형식이 통일되도록 했습니다.
   - 조회한 결과 목록이 비어있을 경우 빈 PageResponse 객체를 반환합니다.