### PR TITLE
Review, LikeReview 리팩토링 및 관련 클래스 구현

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/image/ImageJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/image/ImageJPARepository.java
@@ -1,16 +1,18 @@
 package com.ktc.matgpt.image;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface ImageJPARepository extends JpaRepository<Image, Long> {
-    @Query("select i from Image i " +
-            "where i.review.id = :reviewId")
+    @Query("select i from Image i where i.review.id = :reviewId")
     List<Image> findAllByReviewId(Long reviewId);
 
-    @Query("select i.url from Image i " +
-            "where i.review.id = :reviewId")
+    @Query("select i.url from Image i where i.review.id = :reviewId")
     List<String> findAllImagesByReviewId(Long reviewId);
+
+    @Query("select i.url from Image i where i.review.id = :reviewId")
+    List<String> findFirstImageByReviewId(Long reviewId, Pageable pageable);
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/image/ImageService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/image/ImageService.java
@@ -6,6 +6,7 @@ import com.ktc.matgpt.aws.S3Service;
 import com.ktc.matgpt.tag.TagService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -52,6 +53,11 @@ public class ImageService {
 
     public List<String> getImageUrlsByReviewId(Long reviewId){
         return imageJPARepository.findAllImagesByReviewId(reviewId);
+    }
+
+    public String getFirstImageByReviewId(Long reviewId){
+        List<String> image = imageJPARepository.findFirstImageByReviewId(reviewId, PageRequest.ofSize(1));
+        return (image.isEmpty()) ? null : image.get(0);
     }
 
     @Deprecated

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewResponse.java
@@ -9,24 +9,28 @@ import java.time.LocalDateTime;
 public class LikeReviewResponse {
 
     @Getter @Setter
-    public static class FindLikeReviewPageDTO {
-        private Long id;
+    public static class LikeReviewDTO {
+        private Long reviewId;
         private int rating;
         private String content;
         private LocalDateTime createdAt;
         private String relativeTime;
+        private String imageUrl;
+        private Long storeId;
         private String storeImage;
         private String storeName;
         private int peopleCount;
         private String reviewerName;
         private String reviewerImage;
 
-        public FindLikeReviewPageDTO(Review review, String relativeTime) {
-            this.id = review.getId();
+        public LikeReviewDTO(Review review, String relativeTime, String imageUrl) {
+            this.reviewId = review.getId();
             this.rating = review.getRating();
             this.content = review.getContent();
             this.createdAt = review.getCreatedAt();
             this.relativeTime = relativeTime;
+            this.imageUrl = imageUrl;
+            this.storeId = review.getStore().getId();
             this.storeImage = review.getStore().getStoreImageUrl();
             this.storeName = review.getStore().getName();
             this.peopleCount = review.getPeopleCount();

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewService.java
@@ -4,7 +4,6 @@ import com.ktc.matgpt.review.entity.Review;
 import com.ktc.matgpt.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/likeReview/LikeReviewService.java
@@ -2,6 +2,7 @@ package com.ktc.matgpt.like.likeReview;
 
 import com.ktc.matgpt.review.entity.Review;
 import com.ktc.matgpt.user.entity.User;
+import com.ktc.matgpt.utils.CursorRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,11 +31,8 @@ public class LikeReviewService {
         }
     }
 
-    public List<LikeReview> findReviewsByUserId(Long userId, Long cursorId, int pageSize) {
-        PageRequest page = PageRequest.ofSize(pageSize);
-        List<LikeReview> likeReviewList = likeReviewJPARepository.findAllByUserIdAndOrderByIdDesc(userId, cursorId, page);
-
-        return likeReviewList;
+    public List<LikeReview> findLikeReviewsByUserId(Long userId, CursorRequest page) {
+        return likeReviewJPARepository.findAllByUserIdAndOrderByIdDesc(userId, page.cursorId, page.request);
     }
 
     @Transactional

--- a/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
@@ -35,12 +35,9 @@ public class LikeReviewUseCase {
         Review review = reviewService.findReviewByIdOrThrow(reviewId);
 
         boolean isLikeAdded = likeReviewService.toggleLikeForReview(userRef, review);
-        if (isLikeAdded) {
-            review.plusRecommendCount();
-        }
-        else {
-            review.minusRecommendCount();
-        }
+        if (isLikeAdded) review.plusRecommendCount();
+        else review.minusRecommendCount();
+
         return isLikeAdded;
     }
 

--- a/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
@@ -65,13 +65,11 @@ public class LikeReviewUseCase {
 
     private Paging<Long> getPagingInfo(List<LikeReview> likeReviews) {
         boolean hasNext = false;
-        int numsOfReviews = 0;
+        int numsOfReviews = likeReviews.size();
 
-        if (likeReviews.size() == DEFAULT_PAGE_SIZE+1) {
+        if (numsOfReviews == DEFAULT_PAGE_SIZE_PLUS_ONE) {
+            numsOfReviews--;
             hasNext = true;
-            numsOfReviews = DEFAULT_PAGE_SIZE;
-        } else {
-            numsOfReviews = likeReviews.size();
         }
 
         Long nextCursorId = likeReviews.get(numsOfReviews-1).getId();

--- a/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j

--- a/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/like/usecase/LikeReviewUseCase.java
@@ -25,6 +25,9 @@ public class LikeReviewUseCase {
     private final ReviewService reviewService;
 
     private final static int DEFAULT_PAGE_SIZE = 8;
+    private final static int DEFAULT_PAGE_SIZE_PLUS_ONE = DEFAULT_PAGE_SIZE + 1;
+    private final static PageResponse EMPTY_PAGE_RESPONSE = new PageResponse<>(new Paging<>(false, 0, null, null), null);
+
 
     @Transactional
     public boolean executeToggleLike(Long reviewId, String userEmail) {
@@ -46,9 +49,7 @@ public class LikeReviewUseCase {
         cursorId = Paging.convertNullCursorToMaxValue(cursorId);
         List<LikeReview> likeReviews = likeReviewService.findReviewsByUserId(userRef.getId(), cursorId, DEFAULT_PAGE_SIZE+1);
 
-        if (likeReviews.isEmpty()) {
-            return new PageResponse<>(new Paging<>(false, 0, null, null), null);
-        }
+        if (likeReviews.isEmpty()) return EMPTY_PAGE_RESPONSE;
 
         Paging paging = getPagingInfo(likeReviews);
         likeReviews = likeReviews.subList(0, paging.size());

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewRestController.java
@@ -53,7 +53,7 @@ public class ReviewRestController {
                                               @RequestParam(required = false) Long cursorId,
                                               @RequestParam(required = false) Integer cursor
     ) {
-        PageResponse<?, ReviewResponse.FindPageByStoreIdDTO> responseDTO = reviewService.findPageByStoreId(storeId, sortBy, cursorId, cursor);
+        PageResponse<?, ReviewResponse.StoreReviewDTO> responseDTO = reviewService.findPageByStoreId(storeId, sortBy, cursorId, cursor);
         return ResponseEntity.ok(com.ktc.matgpt.utils.ApiUtils.success(responseDTO));
     }
 

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -49,7 +49,6 @@ public class ReviewService {
     private final StoreService storeService;
     private final LikeReviewService likeReviewService;
     private final MessageSourceAccessor messageSourceAccessor;
-    private final EntityManager entityManager;
 
     private static final int DEFAULT_PAGE_SIZE = 8;
     private static final int DEFAULT_PAGE_SIZE_PLUS_ONE = DEFAULT_PAGE_SIZE + 1;

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -52,6 +52,7 @@ public class ReviewService {
 
     private static final int DEFAULT_PAGE_SIZE = 8;
     private static final int DEFAULT_PAGE_SIZE_PLUS_ONE = DEFAULT_PAGE_SIZE + 1;
+    private static final PageResponse EMPTY_PAGE_RESPONSE = new PageResponse<>(new Paging<>(false, 0, null, null), null);
 
     @Transactional
     public void completeReviewUpload(Long storeId, Long reviewId, ReviewRequest.CreateCompleteDTO requestDTO, String userEmail) {
@@ -147,10 +148,7 @@ public class ReviewService {
             case "likes" -> reviewJPARepository.findAllByStoreIdAndOrderByLikesAndIdDesc(storeId, cursorId, cursor, page);
             default -> throw new CustomException(ErrorCode.INVALID_SORT_TYPE, sortBy);
         };
-
-        if (reviews.isEmpty()) {
-            return new PageResponse<>(new Paging<>(false, 0, null, null), null);
-        }
+        if (reviews.isEmpty()) return EMPTY_PAGE_RESPONSE;
 
         Paging<Integer> paging = getPagingInfo(reviews);
         reviews = reviews.subList(0, paging.size());
@@ -187,6 +185,7 @@ public class ReviewService {
             case "likes" -> reviewJPARepository.findAllByUserIdAndOrderByLikesAndIdDesc(userRef.getId(), cursorId, cursor, page);
             default -> throw new CustomException(ErrorCode.INVALID_SORT_TYPE, sortBy);
         };
+        if (reviewList.isEmpty()) return EMPTY_PAGE_RESPONSE;
 
         if (reviews.isEmpty()) {
             return new PageResponse<>(new Paging<>(false, 0, null, null), null);

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -283,7 +283,7 @@ public class ReviewService {
         if (value != 1) {
             unitKey += "s";
         }
-        return value + " " + unitKey + "ago";
+        return value + " " + unitKey + " ago";
         //        String timeUnitMessage = messageSourceAccessor.getMessage(unitKey, locale);
         //        return value + " " + timeUnitMessage + " " + messageSourceAccessor.getMessage("ago", locale);
     }

--- a/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/ReviewService.java
@@ -252,13 +252,11 @@ public class ReviewService {
 
     private Paging<Integer> getPagingInfo(List<Review> reviews) {
         boolean hasNext = false;
-        int numsOfReviews = 0;
+        int numsOfReviews = reviews.size();
 
-        if (reviews.size() == DEFAULT_PAGE_SIZE+1) {
+        if (numsOfReviews == DEFAULT_PAGE_SIZE_PLUS_ONE) {
+            numsOfReviews -= 1;
             hasNext = true;
-            numsOfReviews = DEFAULT_PAGE_SIZE;
-        } else {
-            numsOfReviews = reviews.size();
         }
 
         Review lastReview = reviews.get(numsOfReviews-1);

--- a/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewResponse.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/dto/ReviewResponse.java
@@ -117,19 +117,19 @@ public class ReviewResponse {
 
     @Getter
     @ToString
-    public static class FindPageByStoreIdDTO {
+    public static class StoreReviewDTO {
         private Long reviewId;
         private int rating;
         private String content;
         private LocalDateTime createdAt;
-        private List<String> imageUrls;
+        private String imageUrl;
         private boolean updated = false;
         private String relativeTime;
         private int numOfLikes;
 
-        public FindPageByStoreIdDTO(Review review, String relativeTime, List<String> imageUrls) {
+        public StoreReviewDTO(Review review, String relativeTime, String imageUrl) {
             this.reviewId = review.getId();
-            this.imageUrls = imageUrls;
+            this.imageUrl = imageUrl;
             this.content = review.getContent();
             this.rating = review.getRating();
             this.createdAt = review.getCreatedAt();
@@ -145,7 +145,7 @@ public class ReviewResponse {
 
     @Getter
     @ToString
-    public static class FindPageByUserIdDTO {
+    public static class UserReviewDTO {
             private Long id;
             private int rating;
             private String content;
@@ -157,7 +157,7 @@ public class ReviewResponse {
             private int numOfLikes;
             private int peopleCount;
 
-            public FindPageByUserIdDTO(Review review, String relativeTime) {
+            public UserReviewDTO(Review review, String relativeTime) {
                 this.id = review.getId();
                 this.rating = review.getRating();
                 this.content = review.getContent();

--- a/matgpt/src/main/java/com/ktc/matgpt/review/mypage/MyPageController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/review/mypage/MyPageController.java
@@ -28,7 +28,7 @@ public class MyPageController {
                                              @RequestParam(required = false) Long cursorId,
                                              @RequestParam(required = false) Integer cursor,
                                              @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        PageResponse<?, ReviewResponse.FindPageByUserIdDTO> responseDTOs =
+        PageResponse<?, ReviewResponse.UserReviewDTO> responseDTOs =
                 reviewService.findPageByUserId(userPrincipal.getEmail(), sortBy, cursorId, cursor);
 
         return ResponseEntity.ok(ApiUtils.success(responseDTOs));
@@ -38,7 +38,7 @@ public class MyPageController {
     @GetMapping("/liked-reviews")
     public ResponseEntity<?> findLikedReviewsByUserId(@RequestParam(required = false) Long cursorId,
                                                       @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        PageResponse<?, LikeReviewResponse.FindLikeReviewPageDTO>  responseDTO
+        PageResponse<?, LikeReviewResponse.LikeReviewDTO>  responseDTO
                             = likeReviewUseCase.executeFindLikeReviews(userPrincipal.getEmail(), cursorId);
         return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }

--- a/matgpt/src/main/java/com/ktc/matgpt/utils/CursorRequest.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/utils/CursorRequest.java
@@ -1,0 +1,30 @@
+package com.ktc.matgpt.utils;
+
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+
+public class CursorRequest<T> {
+    public PageRequest request;
+    public T cursor;
+    public Long cursorId;
+
+    public CursorRequest(int size, T cursor, Class<T> clazz, Long cursorId) {
+        this.request = PageRequest.ofSize(size);
+        this.cursor = convertNullCursorToMaxValue(cursor, clazz);
+        this.cursorId = Paging.convertNullCursorToMaxValue(cursorId);
+    }
+
+    private static <T> T convertNullCursorToMaxValue(T cursor, Class<T> clazz) {
+        if (clazz == Double.class) {
+            return (T) Paging.convertNullCursorToMinValue((Double) cursor);
+        } else if (clazz == Integer.class) {
+            return (T) Paging.convertNullCursorToMaxValue((Integer) cursor);
+        } else if (clazz == Long.class) {
+            return (T) Paging.convertNullCursorToMaxValue((Long) cursor);
+        } else if (clazz == LocalDateTime.class) {
+            return (T) Paging.convertNullCursorToMaxValue((LocalDateTime) cursor);
+        }
+        return null;
+    }
+}

--- a/matgpt/src/main/resources/custom_modified.sql
+++ b/matgpt/src/main/resources/custom_modified.sql
@@ -345,6 +345,25 @@ INSERT INTO likereview_tb (review_id, user_id) VALUES (18, 10);
 INSERT INTO likereview_tb (review_id, user_id) VALUES (13, 11);
 INSERT INTO likereview_tb (review_id, user_id) VALUES (15, 11);
 
+
 INSERT INTO image_tb (review_id, url) VALUES (1, 'image1.png');
+-- reviewId: 8에 image 1~3 등록
+INSERT INTO image_tb (review_id, url) VALUES (8, 'image1_review8.png');
+INSERT INTO image_tb (review_id, url) VALUES (8, 'image2_review8.png');
+INSERT INTO image_tb (review_id, url) VALUES (8, 'image3_review8.png');
+-- reviewId: 9에 image 1~2 등록
+INSERT INTO image_tb (review_id, url) VALUES (9, 'image1_review9.png');
+INSERT INTO image_tb (review_id, url) VALUES (9, 'image2_review9.png');
+
+
+
 INSERT INTO food_tb (store_id, food_name, nums_of_review, avg_rating, created_at, updated_at) VALUES (1, 'food1', 3, 2.5, now(), now());
-INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (1, 1, '볶음밥', 3, 25.08, 36.74);
+
+
+
+INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (1, 1, 'food1', 3, 25.08, 36.74);
+INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (2, 1, 'food1', 3, 25.08, 36.74);
+INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (3, 1, 'food1', 3, 25.08, 36.74);
+INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (4, 1, 'food1', 3, 25.08, 36.74);
+INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (5, 1, 'food1', 3, 25.08, 36.74);
+INSERT INTO tag_tb (image_id, food_id, tag_name, menu_rating, locationx, locationy) VALUES (6, 1, 'food1', 3, 25.08, 36.74);

--- a/matgpt/src/test/java/com/ktc/matgpt/mypage/MyPageControllerTest.java
+++ b/matgpt/src/test/java/com/ktc/matgpt/mypage/MyPageControllerTest.java
@@ -178,10 +178,10 @@ public class MyPageControllerTest {
         // verify
         // 리뷰 데이터 응답 검증 - 리뷰 최신순 x, 리뷰에 좋아요를 누른 최신순으로 정렬된다.
         resultActions.andExpect(status().isOk());
-        resultActions.andExpect(jsonPath("$.data.body[0].id").value("3"));
-        resultActions.andExpect(jsonPath("$.data.body[1].id").value("7"));
-        resultActions.andExpect(jsonPath("$.data.body[2].id").value("2"));
-        resultActions.andExpect(jsonPath("$.data.body[3].id").value("1"));
+        resultActions.andExpect(jsonPath("$.data.body[0].reviewId").value("3"));
+        resultActions.andExpect(jsonPath("$.data.body[1].reviewId").value("7"));
+        resultActions.andExpect(jsonPath("$.data.body[2].reviewId").value("2"));
+        resultActions.andExpect(jsonPath("$.data.body[3].reviewId").value("1"));
         // 페이징 관련 데이터 응답 검증
         resultActions.andExpect(jsonPath("$.data.paging.hasNext").value(false));
         resultActions.andExpect(jsonPath("$.data.paging.nextCursorId").value(1));

--- a/matgpt/src/test/java/com/ktc/matgpt/review/ReviewRestControllerTest.java
+++ b/matgpt/src/test/java/com/ktc/matgpt/review/ReviewRestControllerTest.java
@@ -247,8 +247,15 @@ public class ReviewRestControllerTest {
         resultActions.andExpect(status().isOk());
         resultActions.andExpect(jsonPath("$.data.body[0].reviewId").value("11"));
         resultActions.andExpect(jsonPath("$.data.body[1].reviewId").value("10"));
+
         resultActions.andExpect(jsonPath("$.data.body[2].reviewId").value("9"));
+        // reivewId:9의 대표 이미지 검증
+        resultActions.andExpect(jsonPath("$.data.body[2].imageUrl").value("image1_review9.png"));
+
         resultActions.andExpect(jsonPath("$.data.body[3].reviewId").value("8"));
+        // reivewId:8의 대표 이미지 검증
+        resultActions.andExpect(jsonPath("$.data.body[3].imageUrl").value("image1_review8.png"));
+
         resultActions.andExpect(jsonPath("$.data.body[4].reviewId").value("7"));
         resultActions.andExpect(jsonPath("$.data.body[5].reviewId").value("6"));
         resultActions.andExpect(jsonPath("$.data.body[6].reviewId").value("5"));
@@ -265,6 +272,10 @@ public class ReviewRestControllerTest {
                 get("/stores/"+ storeId +"/reviews?sortBy="+ sortBy +"&cursorId="+ cursorId)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
         );
+        //console
+        responseBody = resultActions.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : "+responseBody);
+
         // verify
         resultActions.andExpect(status().isOk());
         resultActions.andExpect(jsonPath("$.data.body[0].reviewId").value("3"));
@@ -299,8 +310,12 @@ public class ReviewRestControllerTest {
         resultActions.andExpect(status().isOk());
         resultActions.andExpect(jsonPath("$.data.body[0].reviewId").value(11));
         resultActions.andExpect(jsonPath("$.data.body[0].numOfLikes").value(5));
+
         resultActions.andExpect(jsonPath("$.data.body[1].reviewId").value(9));
         resultActions.andExpect(jsonPath("$.data.body[1].numOfLikes").value(3));
+        // reivewId:9의 대표 이미지 검증
+        resultActions.andExpect(jsonPath("$.data.body[1].imageUrl").value("image1_review9.png"));
+
         resultActions.andExpect(jsonPath("$.data.body[2].reviewId").value(2));
         resultActions.andExpect(jsonPath("$.data.body[2].numOfLikes").value(3));
         resultActions.andExpect(jsonPath("$.data.body[3].reviewId").value(1));
@@ -311,8 +326,11 @@ public class ReviewRestControllerTest {
         resultActions.andExpect(jsonPath("$.data.body[5].numOfLikes").value(1));
         resultActions.andExpect(jsonPath("$.data.body[6].reviewId").value(10));
         resultActions.andExpect(jsonPath("$.data.body[6].numOfLikes").value(0));
+
         resultActions.andExpect(jsonPath("$.data.body[7].reviewId").value(8));
-        resultActions.andExpect(jsonPath("$.data.body[7].numOfLikes").value(0));
+        // reivewId:8의 대표 이미지 검증
+        resultActions.andExpect(jsonPath("$.data.body[7].imageUrl").value("image1_review8.png"));
+
         // 페이징 관련 데이터 응답 검증
         resultActions.andExpect(jsonPath("$.data.paging.hasNext").value(true));
         resultActions.andExpect(jsonPath("$.data.paging.nextCursorId").value(8));

--- a/matgpt/src/test/java/com/ktc/matgpt/review/ReviewRestControllerTest.java
+++ b/matgpt/src/test/java/com/ktc/matgpt/review/ReviewRestControllerTest.java
@@ -3,12 +3,9 @@ package com.ktc.matgpt.review;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ktc.matgpt.TestHelper;
 import com.ktc.matgpt.exception.ErrorCode;
-import com.ktc.matgpt.food.FoodService;
-import com.ktc.matgpt.image.ImageService;
 import com.ktc.matgpt.review.dto.ReviewRequest;
 import com.ktc.matgpt.review.dto.ReviewResponse;
 import com.ktc.matgpt.security.UserPrincipal;
-import com.ktc.matgpt.store.StoreService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,15 +47,6 @@ public class ReviewRestControllerTest {
 
     @Mock
     private ReviewService reviewService;
-
-    @Mock
-    private ImageService imageService;
-
-    @Mock
-    private FoodService foodService;
-
-    @Mock
-    private StoreService storeService;
 
     @BeforeEach
     public void setUp() {


### PR DESCRIPTION
## 변경사항
- Review, LikeReview 서비스를 리팩토링했습니다.
   - 조회한 목록이 비어있을 경우 반환하는 빈 PageResponse 객체를 상수로 선언해 사용합니다.
   - findPage~ 메서드에서 응답 DTO를 생성하는 코드를 get~DTO 메서드로 분리했습니다.
   - CursorRequset 클래스를 구현해 레포지토리 조회 호출에 필요한 커서 페이지네이션 정보를 한 번에 초기화했습니다.
      - 생성자 인자로 받은 타입에 따라 Paging 클래스의 알맞은 메서드를 호출합니다.
   - getPagingInfo, executeToggleLike 메서드의 코드를 정리했습니다.
   - getRelativeTime() 반환 메시지에 공백을 추가했습니다.
   
- Review, LikeReview DTO를 수정했습니다.
   - DTO를 수정했습니다.
   - 누락된 storeId와 imageUrl 필드를 추가하고, 리뷰 id 필드명을 reviewId로 통일했습니다.
   - 기존에 리스트였던 imageUrls 필드를 대표 이미지 1개만 응답하는 imageUrl 필드로 수정했습니다.
   
- 대표 이미지를 받아오는 서비스를 추가했습니다.
   - 응답 DTO 필드 변경에 따라 대표 이미지 1장의 url만 받아오는 서비스 메서드를 추가했습니다.
   - 동일한 reviewId를 기준으로 조회할 때, imageId 오름차순으로 1개 image만 받아오는 레포지토리 메서드를 추가했습니다.
   
- 변경사항을 테스트 코드에 반영했습니다.
   - 수정된 DTO에 대해 테스트 코드를 함께 수정했습니다.
   - 1번째 이미지를 대표로 받아오는지 검증을 추가했습니다.
- 불필요한 import, 의존성, 사용하지 않는 메서드를 삭제했습니다.


## 추가 사항
- CursorRequest 클래스는 cursor의 값이 null일 경우 해당 cursor 타입의 최댓값으로 대체하도록 Paging 클래스의 convert 메서드를 호출해야 합니다.
- 이때 CursorRequest 생성자로 받은 인자의 타입에 따라 알맞은 타입의 오버로딩 메서드를 호출해야 합니다.
- 그러나 제네릭 클래스를 사용해 구현하는 도중, 인자로 들어온 cursor가 null일 경우에는 타입을 아예 인식하지 못하는 문제가 있었습니다.
- 호출할 때 Class 타입을 직접 인자로 함께 넘겨준 뒤 if else로 타입을 하나씩 비교하는 방식으로 해결했지만, 더 나은 구현 방식이 필요하다고 생각됩니다.