### PR TITLE
Enhancements in Coin Management and API Response Standardization

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/domain/chatgpt/service/GptOrderGuidanceService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/chatgpt/service/GptOrderGuidanceService.java
@@ -6,6 +6,8 @@ import com.ktc.matgpt.domain.chatgpt.dto.GptOrderGuidanceResponseDto;
 import com.ktc.matgpt.domain.chatgpt.dto.GptRequestConverter;
 import com.ktc.matgpt.domain.chatgpt.entity.GptOrderGuidance;
 import com.ktc.matgpt.domain.chatgpt.repository.GptOrderGuidanceRepository;
+import com.ktc.matgpt.domain.coin.dto.CoinRequest;
+import com.ktc.matgpt.domain.coin.service.CoinService;
 import com.ktc.matgpt.domain.user.entity.LocaleEnum;
 import com.ktc.matgpt.domain.user.entity.User;
 import com.ktc.matgpt.domain.user.service.UserService;
@@ -28,11 +30,16 @@ public class GptOrderGuidanceService {
 
     private final GptOrderGuidanceRepository gptOrderGuidanceRepository;
     private final UserService userService;
+    private final CoinService coinService;
     private final GptApiService gptApiService;
+
+    private static final int DEFAULT_COIN_USAGE = 20;
 
     @Transactional
     public String generateOrderGuidance(Long userId) throws ExecutionException, InterruptedException {
         User user = userService.findById(userId);
+        coinService.useCoin(userId,new CoinRequest.UseCoinDto(DEFAULT_COIN_USAGE));
+
         GptApiRequest requestBody = GptRequestConverter.convertFromLocale(user.getLocale().getCountryDescription());
 
         CompletableFuture<GptApiResponse> completableGptApiResponse = gptApiService.callChatGptApi(requestBody);

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/coin/entity/Coin.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/coin/entity/Coin.java
@@ -23,7 +23,7 @@ public class Coin {
 
     public Coin(User user) {
         this.user = user;
-        this.balance = 0;
+        this.balance = 100;
     }
 
     public static Coin create(User user) {

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/user/controller/UserController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/user/controller/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
     @PostMapping("/info")
     public ResponseEntity<?> editUserInfo(@RequestBody UserDto.Request userDto, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         userService.updateUserAdditionalInfo(userPrincipal.getEmail(),userDto);
-        return ResponseEntity.ok("업데이트가 완료되었습니다.");
+        return ResponseEntity.ok(ApiUtils.success("유저프로필 업데이트 완료"));
     }
 
 

--- a/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthController.java
@@ -4,6 +4,7 @@ import com.ktc.matgpt.domain.user.entity.User;
 import com.ktc.matgpt.security.dto.AuthDto;
 import com.ktc.matgpt.security.dto.TokenDto;
 import com.ktc.matgpt.domain.user.service.UserService;
+import com.ktc.matgpt.utils.ApiUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,26 +20,26 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<TokenDto.Response> signup(@RequestBody AuthDto.DefaultRequest defaultRequest) {
+    public ResponseEntity<?> signup(@RequestBody AuthDto.DefaultRequest defaultRequest) {
         authService.signup(defaultRequest);
-        return ResponseEntity.ok(authService.login(defaultRequest));
+        return ResponseEntity.ok(ApiUtils.success(authService.login(defaultRequest)));
     }
 
     @PostMapping("/login")
-    public ResponseEntity<TokenDto.Response> login(@RequestBody AuthDto.DefaultRequest defaultRequest) {
-        return ResponseEntity.ok(authService.login(defaultRequest));
+    public ResponseEntity<?> login(@RequestBody AuthDto.DefaultRequest defaultRequest) {
+        return ResponseEntity.ok(ApiUtils.success(authService.login(defaultRequest)));
     }
 
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(@RequestBody TokenDto.Request requestDto, HttpServletRequest request) {
         authService.logout(requestDto, request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiUtils.success("로그아웃 완료"));
     }
 
     @PostMapping("/reissue")
-    public ResponseEntity<TokenDto.Response> reissue(@RequestBody TokenDto.Request requestDto, HttpServletRequest request) {
-        return ResponseEntity.ok(authService.reissue(requestDto, request));
+    public ResponseEntity<?> reissue(@RequestBody TokenDto.Request requestDto, HttpServletRequest request) {
+        return ResponseEntity.ok(ApiUtils.success(authService.reissue(requestDto, request)));
     }
 
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.ktc.matgpt.security.auth;
 
+import com.ktc.matgpt.domain.coin.service.CoinService;
 import com.ktc.matgpt.domain.user.entity.User;
 import com.ktc.matgpt.domain.user.repository.UserRepository;
 import com.ktc.matgpt.domain.user.service.UserService;
@@ -29,6 +30,7 @@ public class AuthService {
     private final TokenProvider tokenProvider;
     private final UserRepository userRepository;
     private final UserService userService;
+    private final CoinService coinService;
     private final PasswordEncoder passwordEncoder;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -42,6 +44,7 @@ public class AuthService {
         User user = defaultRequest.toEntity(passwordEncoder);
 
         UserPrincipal.create(user);
+        coinService.createCoin(user); //기본 코인 할당
 
         return AuthDto.DefaultRequest.toDto(userRepository.save(user));
 

--- a/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthService.java
@@ -73,6 +73,8 @@ public class AuthService {
 
     @Transactional
     public void logout(TokenDto.Request tokenRequest, HttpServletRequest request) {
+        Authentication authentication = tokenProvider.getAuthentication(tokenRequest.getAccessToken(),request);
+        refreshTokenRepository.deleteByKey(authentication.getName());
     }
 
     @Transactional

--- a/matgpt/src/main/resources/custom.sql
+++ b/matgpt/src/main/resources/custom.sql
@@ -5,12 +5,12 @@ INSERT INTO category_tb (id, name) VALUES
                                        (3, 'DESSERT'),
                                        (4, 'JAPANESE');
 -- User Table Initalization
-INSERT INTO user_tb (AGE_GROUP, ID, EMAIL, GENDER, NAME, LOCALE, PASSWORD)
-VALUES (2, 1, 'nstgic@gmail.com', 'FEMALE', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7', 'KOREA', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7');
-INSERT INTO user_tb (AGE_GROUP, ID, EMAIL, GENDER, NAME, LOCALE, PASSWORD)
-VALUES (2, 2, 'female@gmail.com', 'FEMALE', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd2','FRANCE', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7');
-INSERT INTO user_tb (AGE_GROUP, ID, EMAIL, GENDER, NAME, LOCALE, PASSWORD)
-VALUES (2 ,3,  'sk980919@kakao.com','MALE', '364ea4bc-65b6-4f27-8682-61ce58896898', 'KOREA', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7');
+INSERT INTO user_tb (AGE_GROUP, ID, EMAIL, profile_image_url,GENDER, NAME, LOCALE, PASSWORD)
+VALUES (2, 1, 'nstgic@gmail.com', '','FEMALE', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7', 'KOREA', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7');
+INSERT INTO user_tb (AGE_GROUP, ID, EMAIL, profile_image_url, GENDER, NAME, LOCALE, PASSWORD)
+VALUES (2, 2, 'female@gmail.com', '','FEMALE', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd2','FRANCE', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7');
+INSERT INTO user_tb (AGE_GROUP, ID, EMAIL, profile_image_url, GENDER, NAME, LOCALE, PASSWORD)
+VALUES (2 ,3,  'sk980919@kakao.com','','MALE', '364ea4bc-65b6-4f27-8682-61ce58896898', 'KOREA', 'ac98bef6-79c0-4a7b-b9b4-9c3e397dbbd7');
 
 
 -- DetailedCategory Table Initialization


### PR DESCRIPTION
## 변경 요약
주문 안내 메서드에 코인 차감 로직 추가
새로운 Coin 인스턴스의 기본 잔액을 100으로 설정, 인증 엔드포인트의 응답 형식 표준화, 그리고 사용자 가입 시 코인 할당 로직 구현

## 변경 배경
API 응답의 일관성의 강화와 플랫폼 내의 코인 관련 기능은 추가하였습니다.

## 변경 사항
- OrderGuidanceService에 코인 차감 로직 추가: 사용자가 주문 안내를 생성할 때마다 코인을 사용합니다.
- Coin 클래스의 생성자 변경: 새로운 코인 인스턴스의 기본 잔액을 100으로 설정합니다.
- 인증 엔드포인트 응답 형식 표준화: signup, login, logout, reissue 엔드포인트에서 ApiUtils.success를 사용하여 응답 형식을 일관되게 합니다.
- 사용자 가입 시 코인 할당 로직 구현: 새로 가입하는 사용자에게 초기 코인 잔액을 할당합니다.

## 테스트 방법
코인 차감 로직: generateOrderGuidance 메서드 호출 시 코인이 차감되는지 확인합니다.
코인 초기 잔액: 새로운 Coin 인스턴스가 생성될 때 기본 잔액이 100인지 확인합니다.
API 응답 형식: 모든 변경된 엔드포인트에서 ApiUtils.success를 통한 응답 형식이 일관되게 반환되는지 확인합니다.
코인 할당 로직: 새로운 사용자가 가입했을 때 초기 코인이 할당되는지 확인합니다.