### PR TITLE
Add S3 Image Upload Processing Logic in UserService

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/domain/user/controller/UserController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.ktc.matgpt.domain.user.controller;
 
+import com.ktc.matgpt.domain.review.dto.ReviewRequest;
+import com.ktc.matgpt.domain.review.dto.ReviewResponse;
+import com.ktc.matgpt.domain.review.entity.Review;
 import com.ktc.matgpt.domain.user.dto.UserDto;
 import com.ktc.matgpt.domain.user.entity.User;
 import com.ktc.matgpt.domain.user.repository.UserRepository;
@@ -11,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +34,23 @@ public class UserController {
     public ResponseEntity<?> editUserInfo(@RequestBody UserDto.Request userDto, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         userService.updateUserAdditionalInfo(userPrincipal.getEmail(),userDto);
         return ResponseEntity.ok("업데이트가 완료되었습니다.");
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping(value = "/image-temp")
+    public ResponseEntity<?> createTemporaryReview(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ResponseEntity.ok(ApiUtils.success(userService.generatePresignedUrl(userPrincipal.getEmail())));
+    }
+
+
+    // 두 번째 단계: 이미지와 태그 정보를 포함하여 리뷰 완료
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/image-complete")
+    public ResponseEntity<?> completeReview(@RequestBody UserDto.ImageRequest imageRequest,
+                                            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        userService.completeImageUpload(imageRequest, userPrincipal.getEmail());
+        return ResponseEntity.ok(ApiUtils.success("업데이트가 성공적으로 완료되었습니다."));
     }
 
 

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/user/dto/UserDto.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/user/dto/UserDto.java
@@ -24,6 +24,14 @@ public class UserDto {
         private int age;
         private String locale;
     }
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ImageRequest {
+        private String email;
+        private String presignedUrl;
+    }
 
     @Getter
     @NoArgsConstructor
@@ -32,6 +40,7 @@ public class UserDto {
     public static class Response {
         private String email;
         private String nickname;
+        private String profileImageUrl;
         private String gender;
         private String age;
         private String locale;
@@ -39,11 +48,13 @@ public class UserDto {
             return new UserDto.Response(
                     user.getEmail(),
                     user.getName(),
+                    user.getProfileImageUrl(),
                     Optional.ofNullable(user.getGender()).map(Enum::toString).orElse(null),
                     Optional.ofNullable(user.getAgeGroup()).map(Enum::toString).orElse(null),
                     Optional.ofNullable(user.getLocale()).map(Enum::name).orElse(null)
             );
         }
+
     }
 
 

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/user/service/UserService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/user/service/UserService.java
@@ -1,5 +1,10 @@
 package com.ktc.matgpt.domain.user.service;
 
+import com.ktc.matgpt.domain.aws.S3Service;
+import com.ktc.matgpt.domain.image.Image;
+import com.ktc.matgpt.domain.review.dto.ReviewRequest;
+import com.ktc.matgpt.domain.review.entity.Review;
+import com.ktc.matgpt.domain.store.Store;
 import com.ktc.matgpt.domain.user.dto.UserDto;
 import com.ktc.matgpt.domain.user.entity.AgeGroup;
 import com.ktc.matgpt.domain.user.entity.Gender;
@@ -7,10 +12,13 @@ import com.ktc.matgpt.domain.user.entity.LocaleEnum;
 import com.ktc.matgpt.domain.user.entity.User;
 import com.ktc.matgpt.domain.user.repository.UserRepository;
 import com.ktc.matgpt.exception.ErrorMessage;
+import com.ktc.matgpt.exception.auth.UnAuthorizedException;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URL;
 import java.util.List;
 import java.util.NoSuchElementException;
 
@@ -20,6 +28,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final EntityManager entityManager;
+    private final S3Service s3Service;
 
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
@@ -60,6 +69,18 @@ public class UserService {
 
         userRepository.save(user);
     }
+    @Transactional
+    public String generatePresignedUrl(String email) {
+        URL presignedUrl = s3Service.getPresignedUrl(String.format("users/%s", email));
+        return presignedUrl.toString();
+    }
 
-    public void updateUserProfileImage(String email){return;} // TODO
+    @Transactional
+    public void completeImageUpload(UserDto.ImageRequest imageRequest, String userEmail) {
+        User user = findByEmail(userEmail);
+        user.setProfileImageUrl(imageRequest.getPresignedUrl());
+
+        userRepository.save(user);
+    }
+
 }


### PR DESCRIPTION
## 변경 요약
이 PR은 리뷰 이미지 업로드 프로세스를 처리하기 위한 ReviewController의 새로운 엔드포인트와 UserService에서의 S3 이미지 업로드 처리 로직을 추가

## 변경 배경
사용자가 리뷰를 위한 이미지를 보다 안전하고 효율적으로 업로드할 수 있도록 지원하는 기능을 개발하는 것이 이 변경의 목적입니다. 
이를 위해 사전 서명된 URL을 생성하고, 사용자가 업로드한 이미지를 프로필에 반영하는 과정이 필요했습니다.

## 변경 사항
ReviewController에 새로운 엔드포인트 추가:
- /image-temp: 이미지 업로드를 위한 사전 서명된 URL을 생성하는 GET 엔드포인트.
- /image-complete: 이미지와 태그 정보를 포함하여 리뷰를 완료하는 POST 엔드포인트.
UserService에서의 S3 이미지 업로드 로직 구현:
- generatePresignedUrl: 사용자별 이메일 주소를 기반으로 한 사전 서명된 URL 생성.
- completeImageUpload: 업로드된 이미지 URL을 사용자 프로필에 반영.