### PR TITLE
Feature/exception

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/exception/GlobalExceptionHandler.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ktc.matgpt.exception;
 
 import com.ktc.matgpt.exception.api.ApiException;
+import com.ktc.matgpt.exception.auth.UserAlreadyExistsException;
 import com.ktc.matgpt.utils.ApiUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,6 +19,11 @@ import java.util.NoSuchElementException;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<?> handleUserAlreadyExistsException(UserAlreadyExistsException ex) {
+        return createErrorResponse(HttpStatus.BAD_REQUEST,ex.getMessage());
+    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex){

--- a/matgpt/src/main/java/com/ktc/matgpt/exception/auth/UserAlreadyExistsException.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/exception/auth/UserAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.ktc.matgpt.exception.auth;
+
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/security/auth/AuthService.java
@@ -6,6 +6,7 @@ import com.ktc.matgpt.domain.user.repository.UserRepository;
 import com.ktc.matgpt.domain.user.service.UserService;
 import com.ktc.matgpt.exception.ErrorMessage;
 import com.ktc.matgpt.exception.auth.InvalidTokenException;
+import com.ktc.matgpt.exception.auth.UserAlreadyExistsException;
 import com.ktc.matgpt.security.UserPrincipal;
 import com.ktc.matgpt.security.dto.AuthDto;
 import com.ktc.matgpt.security.dto.TokenDto;
@@ -38,7 +39,7 @@ public class AuthService {
     @Transactional
     public AuthDto.DefaultRequest signup(AuthDto.DefaultRequest defaultRequest) {
         if (userService.existsByEmail(defaultRequest.getEmail())) {
-            throw new RuntimeException(ErrorMessage.USER_ALREADY_EXIST);
+            throw new UserAlreadyExistsException(ErrorMessage.USER_ALREADY_EXIST);
         }
 
         User user = defaultRequest.toEntity(passwordEncoder);


### PR DESCRIPTION
## 변경 요약
이  PR은 GlobalExceptionHandler에 UserAlreadyExistsException 처리를 추가하고, 사용자 중복 생성 시 발생하는 일반 RuntimeException을 UserAlreadyExistsException으로 변경

## 변경 배경
시스템에서 이미 존재하는 사용자를 다시 생성하려고 할 때, 보다 명확한 예외 처리와 오류 메시지를 제공하는 것이 필요했습니다. 이를 위해 특정 예외 처리 로직을 개선하고, 사용자 중복 생성 시 발생하는 예외를 명시적으로 만들어 오류 핸들링을 강화

## 변경 사항
GlobalExceptionHandler에 UserAlreadyExistsException 추가:
- 사용자 중복 생성 시 발생하는 예외를 전역적으로 처리하기 위한 로직 추가.
UserAlreadyExistsException을 던지는 로직 구현:
- 기존에 일반 RuntimeException을 사용하던 부분을 UserAlreadyExistsException으로 변경하여, 사용자 중복 생성 시 보다 구체적인 예외 처리 가능.