### PR TITLE
User 이미지 저장 로직 수정, Tag 삭제 수정

### DIFF
--- a/matgpt/src/main/java/com/ktc/matgpt/domain/aws/S3Service.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/aws/S3Service.java
@@ -21,7 +21,8 @@ public class S3Service {
 
     @Value("${cloud.aws.s3.bucket}")
     private String s3BucketName;
-    private static Pattern urlPattern = Pattern.compile("https://matgpt-dev\\.s3\\.ap-northeast-2\\.amazonaws\\.com/reviews/[\\w-]+/\\d+");
+    private static Pattern reviewPattern = Pattern.compile("https://matgpt-dev\\.s3\\.ap-northeast-2\\.amazonaws\\.com/reviews/[\\w-]+/\\d+");
+    private static Pattern userPattern = Pattern.compile("https://matgpt-dev\\.s3\\.ap-northeast-2\\.amazonaws\\.com/users/\\d+");
     private static Pattern keyPatten = Pattern.compile("reviews/[\\w-]+/\\d+");
 
     public URL getPresignedUrl(String objectKey) {
@@ -37,8 +38,16 @@ public class S3Service {
         return amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
     }
 
-    public String getS3Url(String presignedUrl) {
-        Matcher matcher = urlPattern.matcher(presignedUrl);
+    public String getReviewImageUrl(String presignedUrl) {
+        Matcher matcher = reviewPattern.matcher(presignedUrl);
+        if (!matcher.find()) throw new NoSuchElementException(ErrorMessage.INVALID_S3_URL);
+
+        String s3Url = matcher.group();
+        return s3Url;
+    }
+
+    public String getUserImageUrl(String presignedUrl) {
+        Matcher matcher = userPattern.matcher(presignedUrl);
         if (!matcher.find()) throw new NoSuchElementException(ErrorMessage.INVALID_S3_URL);
 
         String s3Url = matcher.group();

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/image/ImageService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/image/ImageService.java
@@ -27,7 +27,7 @@ public class ImageService {
     @Transactional
     public Image saveImageForReview(Review review, String presignedUrl) {
         log.info("presignedUrl : {}", presignedUrl);
-        String s3Url = s3Service.getS3Url(presignedUrl);
+        String s3Url = s3Service.getReviewImageUrl(presignedUrl);
 
         Image image = Image.create(review, s3Url);
         imageJPARepository.save(image);

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/tag/TagJPARepository.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/tag/TagJPARepository.java
@@ -10,4 +10,5 @@ public interface TagJPARepository extends JpaRepository<Tag, Long> {
             "where t.image.id = :imageId")
     List<Tag> findAllByImageId(Long imageId);
 
+    void deleteAllByImageId(Long imageId);
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/tag/TagService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/tag/TagService.java
@@ -37,7 +37,8 @@ public class TagService {
         }
 
         updateFoodBeforeDelete(tags); // 필요한 업데이트를 먼저 처리
-        bulkDeleteTags(tags); // 태그들을 Bulk Delete를 통해 삭제
+//        bulkDeleteTags(tags); // 태그들을 Bulk Delete를 통해 삭제
+        tagJPARepository.deleteAllByImageId(imageId);
     }
 
     public List<Tag> getTagsByImageId(Long imageId) {
@@ -49,8 +50,8 @@ public class TagService {
         tags.forEach(foodService::removeRatingByTagName);
     }
 
-    private void bulkDeleteTags(List<Tag> tags) {
-        tagJPARepository.deleteAllInBatch(tags); // Spring Data JPA의 Bulk Delete를 수행
-        tags.forEach(tag -> log.info("tag-{}: 태그를 삭제했습니다.", tag.getId()));
-    }
+//    private void bulkDeleteTags(List<Tag> tags) {
+//        tagJPARepository.deleteAllInBatch(tags); // Spring Data JPA의 Bulk Delete를 수행
+//        tags.forEach(tag -> log.info("tag-{}: 태그를 삭제했습니다.", tag.getId()));
+//    }
 }

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/user/controller/UserController.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/user/controller/UserController.java
@@ -43,7 +43,6 @@ public class UserController {
     }
 
 
-    // 두 번째 단계: 이미지와 태그 정보를 포함하여 리뷰 완료
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/image-complete")
     public ResponseEntity<?> completeReview(@RequestBody UserDto.ImageRequest imageRequest,

--- a/matgpt/src/main/java/com/ktc/matgpt/domain/user/service/UserService.java
+++ b/matgpt/src/main/java/com/ktc/matgpt/domain/user/service/UserService.java
@@ -78,7 +78,8 @@ public class UserService {
     @Transactional
     public void completeImageUpload(UserDto.ImageRequest imageRequest, String userEmail) {
         User user = findByEmail(userEmail);
-        user.setProfileImageUrl(imageRequest.getPresignedUrl());
+        String userImageUrl = s3Service.getUserImageUrl(imageRequest.getPresignedUrl());
+        user.setProfileImageUrl(userImageUrl);
 
         userRepository.save(user);
     }


### PR DESCRIPTION
## 변경 내용
- User Image 저장 로직을 수정했습니다.
   - 요청DTO의 presigned url에서 실제 회원 이미지 url을 추출해 저장하도록 했습니다.
- Tag 삭제 로직을 수정했습니다.
   -  tag 삭제를 bulk delete로 구현한 부분을 주석처리했습니다.
   - deleteAllByImageId로 수정했습니다.